### PR TITLE
Implement dynamic theme loading

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1440,50 +1440,7 @@ class ExcelViewer(QWidget):
         dialog.setWindowTitle("SQL IN Clauses")
         dialog.setMinimumSize(600, 500)
         
-        # Apply dark theme
-        dialog.setStyleSheet("""
-            QDialog {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-            }
-            QTextEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                font-family: Consolas, monospace;
-            }
-            QLabel {
-                color: #e0e0e0;
-                font-weight: bold;
-            }
-            QLabel.warning {
-                color: #ffaa00;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QCheckBox {
-                color: #e0e0e0;
-            }
-            QListWidget {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-            }
-            QListWidget::item {
-                padding: 4px;
-            }
-            QListWidget::item:selected {
-                background-color: #3a6ea5;
-            }
-        """)
+        # Use application theme for styling
         
         # Create layout
         layout = QVBoxLayout(dialog)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -48,6 +48,8 @@ class MainWindow(QMainWindow):
         
         # Set up the UI
         self.init_ui()
+        # Apply theme after UI is created
+        self.apply_theme()
         
         # Connect to database
         self.connect_to_database()
@@ -816,45 +818,7 @@ class MainWindow(QMainWindow):
         dialog.setWindowTitle("Select Sheets to Compare")
         dialog.setMinimumSize(400, 300)
         
-        # Apply dark theme styling to match the rest of the app
-        dialog.setStyleSheet("""
-            QDialog { 
-                background-color: #2d2d2d; 
-                color: #e0e0e0; 
-            }
-            QListWidget { 
-                background-color: #333333; 
-                color: #e0e0e0; 
-                border: 1px solid #555555;
-            }
-            QLabel { 
-                color: #e0e0e0; 
-                font-weight: bold;
-                background: transparent;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QComboBox {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-            QLineEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-        """)
+        # Use application theme for styling
         
         layout = QVBoxLayout(dialog)
         
@@ -1166,6 +1130,8 @@ class MainWindow(QMainWindow):
                 tolerance = self.config.get("excel", "numerical_comparison_tolerance")
                 self.comparison_engine.set_tolerance(tolerance)
                 
+            # Apply updated theme
+            self.apply_theme()
             self.status_bar.showMessage("Settings updated")
     
     def show_about(self):
@@ -1451,3 +1417,18 @@ class MainWindow(QMainWindow):
 
     def update_button_states(self, has_data):
         self.export_pdf_button.setEnabled(has_data)
+
+    def apply_theme(self):
+        """Apply application-wide stylesheet based on configuration"""
+        theme = self.config.get("ui", "theme")
+        if not theme or theme.lower() == "system":
+            QApplication.instance().setStyleSheet("")
+            return
+
+        themes_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes")
+        theme_file = os.path.join(themes_dir, f"{theme.lower()}.qss")
+        if os.path.exists(theme_file):
+            with open(theme_file, "r", encoding="utf-8") as f:
+                QApplication.instance().setStyleSheet(f.read())
+        else:
+            QApplication.instance().setStyleSheet("")

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -13,6 +13,7 @@ class SettingsDialog(QDialog):
     def __init__(self, config, parent=None):
         super().__init__(parent)
         self.config = config
+        self.parent_window = parent
         self.init_ui()
         self.load_settings()
         
@@ -184,6 +185,8 @@ class SettingsDialog(QDialog):
         theme_map = {"light": 0, "dark": 1, "system": 2}
         theme = self.config.get("ui", "theme")
         self.theme.setCurrentIndex(theme_map.get(theme.lower(), 0))
+        # Connect after setting initial value to avoid unnecessary update
+        self.theme.currentIndexChanged.connect(self._on_theme_changed)
         
         self.font_size.setValue(self.config.get("ui", "font_size"))
         self.show_line_numbers.setChecked(self.config.get("ui", "show_line_numbers"))
@@ -193,6 +196,13 @@ class SettingsDialog(QDialog):
         self.auto_generate.setChecked(self.config.get("testing", "auto_generate_queries"))
         self.show_suggestions.setChecked(self.config.get("testing", "show_suggestions"))
         self.comparison_threshold.setValue(self.config.get("testing", "comparison_threshold") * 100)  # Convert to percentage
+
+    def _on_theme_changed(self, index):
+        """Apply theme immediately when the user selects a new option"""
+        theme_options = ["light", "dark", "system"]
+        self.config.set("ui", "theme", theme_options[index])
+        if self.parent_window and hasattr(self.parent_window, "apply_theme"):
+            self.parent_window.apply_theme()
     
     def save_settings(self):
         """Save settings to configuration"""

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -1,0 +1,11 @@
+QWidget {
+    background-color: #2d2d2d;
+    color: #e0e0e0;
+}
+QPushButton {
+    background-color: #3a6ea5;
+    color: white;
+}
+QPushButton:hover {
+    background-color: #4a7eb5;
+}

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -1,0 +1,4 @@
+QWidget {
+    background-color: #ffffff;
+    color: #000000;
+}


### PR DESCRIPTION
## Summary
- load stylesheet themes via new `MainWindow.apply_theme`
- centralize QSS files under `themes/`
- update settings dialog to apply theme immediately
- remove inline dialog styling

## Testing
- `python -m pip install pytest` *(fails: Could not find a matching distribution)*