### PR TITLE
Add tests for comparison engine and DB connector

### DIFF
--- a/tests/fixtures/excel_data.csv
+++ b/tests/fixtures/excel_data.csv
@@ -1,0 +1,3 @@
+Center,CAReportName,Amount
+1,1234-5678,100
+2,9999-0000,50

--- a/tests/fixtures/sql_data.csv
+++ b/tests/fixtures/sql_data.csv
@@ -1,0 +1,3 @@
+Center,CAReportName,Amount
+1,1234-5678,-100
+2,9999-0000,50

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+import pandas as pd
+from src.analyzer.comparison_engine import ComparisonEngine
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+class TestComparisonEngineSignFlip(unittest.TestCase):
+    def setUp(self):
+        self.excel_df = pd.read_csv(os.path.join(FIXTURES, 'excel_data.csv'))
+        self.sql_df = pd.read_csv(os.path.join(FIXTURES, 'sql_data.csv'))
+        self.engine = ComparisonEngine()
+
+    def test_sign_flip(self):
+        result_no_flip = self.engine.compare_dataframes(self.excel_df, self.sql_df)
+        self.assertGreater(result_no_flip['summary']['mismatch_percentage'], 0)
+
+        self.engine.set_sign_flip_accounts(['1234-5678'])
+        result_flip = self.engine.compare_dataframes(self.excel_df, self.sql_df)
+        self.assertEqual(result_flip['summary']['mismatch_percentage'], 0)
+        self.assertTrue(result_flip['summary']['overall_match'])
+
+    def test_detailed_dataframe_mismatch(self):
+        sql_mod = self.sql_df.copy()
+        sql_mod.loc[0, 'Amount'] = -90
+        self.engine.set_sign_flip_accounts(['1234-5678'])
+        df = self.engine.generate_detailed_comparison_dataframe('Sheet1', self.excel_df, sql_mod)
+        self.assertIn('Does Not Match', df['Result'].values)

--- a/tests/test_db_connector.py
+++ b/tests/test_db_connector.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import MagicMock
+from src.database.db_connector import DatabaseConnector
+
+class TestDatabaseConnector(unittest.TestCase):
+    def test_execute_query_success(self):
+        db = DatabaseConnector()
+        db.engine = MagicMock()
+        conn = MagicMock()
+        db.engine.connect.return_value.__enter__.return_value = conn
+        result = MagicMock()
+        result.returns_rows = True
+        result.keys.return_value = ['a', 'b']
+        result.fetchall.return_value = [(1, 'x'), (2, 'y')]
+        conn.execute.return_value = result
+
+        data = db.execute_query('SELECT')
+        self.assertEqual(data['columns'], ['a', 'b'])
+        self.assertEqual(len(data['data']), 2)
+        self.assertEqual(data['data'][0]['a'], 1)
+
+    def test_execute_query_error(self):
+        db = DatabaseConnector()
+        db.engine = MagicMock()
+        db.engine.connect.side_effect = Exception('fail')
+        res = db.execute_query('SELECT')
+        self.assertIn('error', res)
+
+    def test_execute_transaction(self):
+        db = DatabaseConnector()
+        db.engine = MagicMock()
+        conn = MagicMock()
+        db.engine.begin.return_value.__enter__.return_value = conn
+        result1 = MagicMock()
+        result1.returns_rows = False
+        result2 = MagicMock()
+        result2.returns_rows = True
+        result2.keys.return_value = ['x']
+        result2.fetchall.return_value = [(1,), (2,)]
+        conn.execute.side_effect = [result1, result2]
+
+        data = db.execute_transaction(['Q1', 'Q2'])
+        self.assertEqual(data['columns'], ['x'])
+        self.assertEqual(len(data['data']), 2)


### PR DESCRIPTION
## Summary
- add fixtures for sign-flip tests
- test ComparisonEngine sign-flip and mismatch reporting
- add unit tests for DatabaseConnector query execution

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError for pandas/sqlalchemy)*