### PR TITLE
Add sign flip suggestion feature

### DIFF
--- a/src/analyzer/api.py
+++ b/src/analyzer/api.py
@@ -12,5 +12,10 @@ def compare_and_report(sheet_name: str, excel_df: pd.DataFrame, sql_df: pd.DataF
     engine.set_tolerance(tolerance)
     engine.set_sign_flip_accounts(sign_flip_accounts)
     results = engine.compare_dataframes(excel_df, sql_df)
-    report = generate_report(sheet_name, results, sign_flip_accounts)
+    report = generate_report(
+        sheet_name,
+        results,
+        sign_flip_accounts,
+        results.get("suggested_sign_flips"),
+    )
     return results, report

--- a/src/analyzer/report_generator.py
+++ b/src/analyzer/report_generator.py
@@ -1,7 +1,12 @@
 from typing import Dict, Iterable
 
 
-def generate_report(sheet_name: str, comparison_results: Dict, sign_flip_accounts: Iterable[str] = None) -> str:
+def generate_report(
+    sheet_name: str,
+    comparison_results: Dict,
+    sign_flip_accounts: Iterable[str] = None,
+    suggested_accounts: Iterable[str] = None,
+) -> str:
     """Create a simple markdown report summarizing comparison results."""
     lines = [f"# Comparison Report: {sheet_name}", ""]
     mismatch_pct = comparison_results.get("summary", {}).get("mismatch_percentage", 0)
@@ -28,4 +33,7 @@ def generate_report(sheet_name: str, comparison_results: Dict, sign_flip_account
     if sign_flip_accounts:
         lines.append("")
         lines.append("**Sign Flip Accounts Applied:** " + ", ".join(sorted(sign_flip_accounts)))
+    if suggested_accounts:
+        lines.append("")
+        lines.append("**Suggested Sign Flip Accounts:** " + ", ".join(sorted(suggested_accounts)))
     return "\n".join(lines)

--- a/tests/test_helper_modules.py
+++ b/tests/test_helper_modules.py
@@ -33,9 +33,10 @@ class TestHelperModules(unittest.TestCase):
             'summary': {'mismatch_percentage': 0, 'matching_cells': 3, 'total_cells': 3},
             'row_counts': {'excel': 2, 'sql': 2, 'matched': 2}
         }
-        report = report_generator.generate_report('Sheet1', comparison_results, ['1234-5678'])
+        report = report_generator.generate_report('Sheet1', comparison_results, ['1234-5678'], ['1111-2222'])
         self.assertIn('PERFECT MATCH', report)
         self.assertIn('Sign Flip Accounts Applied', report)
+        self.assertIn('Suggested Sign Flip Accounts', report)
 
     def test_api_compare_and_report(self):
         from src.analyzer.api import compare_and_report


### PR DESCRIPTION
## Summary
- suggest sign flip accounts when numeric mismatches can be resolved by flipping sign
- show suggestions in comparison report and API
- add ability to display suggestions in tests

## Testing
- `pytest -q` *(fails: command not found)*