### PR TITLE
Update README usage details and add example results CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ python src/analyzer/run_real_query.py
 ```
 
 ### Generate the PDF report
-Run the report generator after tests have produced a `results.csv` file:
+First save your comparison results to a CSV file. In the GUI this can be done
+via **File -> Export Results**. Scripts under `src/analyzer` can also write the
+output directly. Once you have a `results.csv` (see
+`sample_data/comparison_results.csv` for an example), run:
 ```
 python src/reporting/generate_pdf_report.py
 ```

--- a/sample_data/comparison_results.csv
+++ b/sample_data/comparison_results.csv
@@ -1,0 +1,4 @@
+Sheet,Center,CAReport Name,Field,Excel Value,DataBase Value,Variance,Result
+SampleSheet,1001-001,Account A,Center,1001-001,1001-001,,Match
+SampleSheet,1001-001,Account A,Amount,100,105,5,Fail
+SampleSheet,1002-002,Account B,Amount,200,200,0,Match


### PR DESCRIPTION
## Summary
- explain exporting comparison results before generating PDF reports
- add `comparison_results.csv` example under `sample_data/`

## Testing
- `pytest -q` *(fails: command not found)*