### PR TITLE
Add sign flip account suggestions

### DIFF
--- a/src/ui/comparison_view.py
+++ b/src/ui/comparison_view.py
@@ -150,9 +150,28 @@ class ComparisonView(QWidget):
         except ValueError:
             pass
 
+        # --- Extract suggested sign flip accounts ---
+        suggested_accounts = []
+        for idx, ln in enumerate(lines):
+            if ln.startswith('**Suggested Sign Flip Accounts:**'):
+                acct_str = ln.split(':', 1)[1].strip()
+                suggested_accounts = [a.strip() for a in acct_str.split(',') if a.strip()]
+                break
+            if ln.strip() == '#### Suggested Sign-Flip Accounts':
+                for sub in lines[idx + 1:]:
+                    if not sub.startswith('- '):
+                        break
+                    suggested_accounts.append(sub[2:].strip())
+                break
+
+        parts = []
         if summary_items:
-            bullet_html = '<ul>' + ''.join(f'<li>{item}</li>' for item in summary_items) + '</ul>'
-            self.summary_content.setText(bullet_html)
+            parts.append('<ul>' + ''.join(f'<li>{item}</li>' for item in summary_items) + '</ul>')
+        if suggested_accounts:
+            parts.append('<p><b>Suggested Sign-Flip Accounts:</b> ' + ', '.join(suggested_accounts) + '</p>')
+
+        if parts:
+            self.summary_content.setText(''.join(parts))
         else:
             self.summary_content.setText("No summary information available.")
             

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -969,12 +969,19 @@ class MainWindow(QMainWindow):
             report.append(f"- Excel records: {excel_rows}")
             report.append(f"- SQL records: {sql_rows}")
             report.append(f"- Matched records: {matched_rows}")
-            
+
             if excel_only > 0 or sql_only > 0:
                 if excel_only > 0:
                     report.append(f"- Excel-only records: {excel_only}")
                 if sql_only > 0:
                     report.append(f"- SQL-only records: {sql_only}")
+
+            # Suggested sign flip accounts for this sheet
+            suggested = results.get("suggested_sign_flips")
+            if suggested:
+                report.append("\n#### Suggested Sign-Flip Accounts")
+                for acct in sorted(suggested):
+                    report.append(f"- {acct}")
             
             # Problem columns with highest mismatch rates
             column_stats = []


### PR DESCRIPTION
## Summary
- show sign flip account suggestions in the per-sheet report
- surface suggested sign-flip accounts in the summary view

## Testing
- `pytest -q` *(fails: command not found)*