### PR TITLE
Add plugin system to ComparisonEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ Use `pytest` to run the unit tests:
 pytest
 ```
 
+## Plugins
+
+The comparison engine can be extended at runtime using plugins. Plugins are
+simple Python classes placed in the `src/plugins/` directory or in a custom
+directory provided to `ComparisonEngine`. Each plugin subclasses
+`plugins.Plugin` and may override `pre_compare` and `post_compare` hooks.
+
+Example plugin that rounds numeric values before comparison:
+
+```python
+from src.plugins import Plugin
+
+class RoundingPlugin(Plugin):
+    def pre_compare(self, excel_df, sql_df):
+        return excel_df.round(2), sql_df.round(2)
+```
+
+Create a new file in `src/plugins/` with your plugin class and restart the
+application. Plugins can also perform tasks such as account validation or
+custom logging.
+
 ## Project Structure
 
 - `main.py` - Main application entry point

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Plugin system for extending the comparison engine."""
+
+from pathlib import Path
+import importlib.util
+import inspect
+from typing import Iterable, List, Type
+
+
+class Plugin:
+    """Base plugin class.
+
+    Plugins can override :meth:`pre_compare` and :meth:`post_compare` to
+    customize comparison behaviour. Both methods should return the (possibly
+    modified) objects they receive.
+    """
+
+    def pre_compare(self, excel_df, sql_df):
+        """Hook executed before dataframe comparison."""
+        return excel_df, sql_df
+
+    def post_compare(self, results):
+        """Hook executed after comparison is complete."""
+        return results
+
+
+def _load_from_file(file: Path) -> List[Plugin]:
+    plugins: List[Plugin] = []
+    spec = importlib.util.spec_from_file_location(file.stem, file)
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        for obj in module.__dict__.values():
+            if inspect.isclass(obj) and issubclass(obj, Plugin) and obj is not Plugin:
+                plugins.append(obj())
+    return plugins
+
+
+def load_plugins(directories: Iterable[Path | str] | None = None) -> List[Plugin]:
+    """Load plugins from the given directories."""
+    if directories is None:
+        directories = [Path(__file__).parent]
+    loaded: List[Plugin] = []
+    for directory in directories:
+        dir_path = Path(directory)
+        if not dir_path.exists():
+            continue
+        for file in dir_path.glob("*.py"):
+            if file.name == "__init__.py":
+                continue
+            try:
+                loaded.extend(_load_from_file(file))
+            except Exception:
+                # Ignore faulty plugins but continue loading others
+                pass
+    return loaded
+
+__all__ = ["Plugin", "load_plugins"]

--- a/tests/plugins/dummy_plugin.py
+++ b/tests/plugins/dummy_plugin.py
@@ -1,0 +1,15 @@
+from src.plugins import Plugin
+
+class DummyPlugin(Plugin):
+    def __init__(self):
+        self.pre_called = False
+        self.post_called = False
+
+    def pre_compare(self, excel_df, sql_df):
+        self.pre_called = True
+        return excel_df, sql_df
+
+    def post_compare(self, results):
+        self.post_called = True
+        results['plugin_executed'] = True
+        return results

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,18 @@
+import os
+import pandas as pd
+from src.analyzer.comparison_engine import ComparisonEngine
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+PLUGIN_DIR = os.path.join(os.path.dirname(__file__), 'plugins')
+
+
+def test_plugin_hooks_called():
+    excel_df = pd.read_csv(os.path.join(FIXTURES, 'excel_data.csv'))
+    sql_df = pd.read_csv(os.path.join(FIXTURES, 'sql_data.csv'))
+    engine = ComparisonEngine(plugin_dirs=[PLUGIN_DIR])
+    result = engine.compare_dataframes(excel_df, sql_df)
+    plugin = engine.plugins[0]
+    assert plugin.pre_called
+    assert plugin.post_called
+    assert result.get('plugin_executed') is True
+


### PR DESCRIPTION
## Summary
- create `plugins` package with base `Plugin` class and loader
- allow `ComparisonEngine` to load plugins and invoke pre/post hooks
- document plugin usage in the README
- test plugin integration

## Testing
- `pytest -q` *(fails: command not found)*