### PR TITLE
Add brand theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A high-quality application for testing Excel reports against SQL databases, espe
 - Support for all Excel sheets and formats
 - Intelligent data matching algorithms
 - Configurable report types and parameters
+- Choose from Light, Dark, Brand, or System interface themes
 
 ## Requirements
 
@@ -42,6 +43,9 @@ or simply use the console script:
 ```
 soo-preclose-tester
 ```
+
+You can customize the appearance under **Tools -> Settings -> User Interface**.
+The Theme drop-down now includes a *Brand* option that applies the company's colors.
 
 For temp table query testing, you can use the specialized scripts:
 ```

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1459,7 +1459,10 @@ class MainWindow(QMainWindow):
             return
 
         themes_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes")
-        theme_file = os.path.join(themes_dir, f"{theme.lower()}.qss")
+        if theme.lower() == "brand":
+            theme_file = os.path.join(themes_dir, "brand.qss")
+        else:
+            theme_file = os.path.join(themes_dir, f"{theme.lower()}.qss")
         if os.path.exists(theme_file):
             with open(theme_file, "r", encoding="utf-8") as f:
                 QApplication.instance().setStyleSheet(f.read())

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -127,7 +127,7 @@ class SettingsDialog(QDialog):
         
         # Theme selection
         self.theme = QComboBox()
-        self.theme.addItems(["Light", "Dark", "System"])
+        self.theme.addItems(["Light", "Dark", "System", "Brand"])
         layout.addRow("Theme:", self.theme)
         
         # Font size
@@ -182,7 +182,7 @@ class SettingsDialog(QDialog):
         self.skip_empty_cols.setChecked(self.config.get("excel", "skip_empty_columns"))
         
         # UI settings
-        theme_map = {"light": 0, "dark": 1, "system": 2}
+        theme_map = {"light": 0, "dark": 1, "system": 2, "brand": 3}
         theme = self.config.get("ui", "theme")
         self.theme.setCurrentIndex(theme_map.get(theme.lower(), 0))
         # Connect after setting initial value to avoid unnecessary update
@@ -199,7 +199,7 @@ class SettingsDialog(QDialog):
 
     def _on_theme_changed(self, index):
         """Apply theme immediately when the user selects a new option"""
-        theme_options = ["light", "dark", "system"]
+        theme_options = ["light", "dark", "system", "brand"]
         self.config.set("ui", "theme", theme_options[index])
         if self.parent_window and hasattr(self.parent_window, "apply_theme"):
             self.parent_window.apply_theme()
@@ -218,7 +218,7 @@ class SettingsDialog(QDialog):
         self.config.set("excel", "skip_empty_columns", self.skip_empty_cols.isChecked())
         
         # UI settings
-        theme_options = ["light", "dark", "system"]
+        theme_options = ["light", "dark", "system", "brand"]
         self.config.set("ui", "theme", theme_options[self.theme.currentIndex()])
         
         self.config.set("ui", "font_size", self.font_size.value())

--- a/themes/brand.qss
+++ b/themes/brand.qss
@@ -1,0 +1,23 @@
+QWidget {
+    background-color: #ffffff;
+    color: #004B8D;
+    font-family: "Proxima Nova", Arial, sans-serif;
+}
+QPushButton {
+    background-color: #279594;
+    color: white;
+}
+QPushButton:hover {
+    background-color: #F58025;
+}
+QMenuBar {
+    background-color: #3B6E8F;
+    color: white;
+}
+QStatusBar {
+    background-color: #76A240;
+    color: white;
+}
+QHeaderView::section {
+    background-color: #9ABDAA;
+}


### PR DESCRIPTION
## Summary
- create `brand.qss` with company colors and font
- allow choosing **Brand** theme in settings
- load `brand.qss` in the main window
- document the new theme option in README

## Testing
- `pytest -q` *(fails: command not found)*