### PR TITLE
Update packaging to include resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,10 @@ soo-preclose-tester = "soo_preclose_tester.__main__:run"
 [tool.setuptools.packages.find]
 include = ["src*", "soo_preclose_tester*"]
 exclude = ["tests*"]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"src" = ["../themes/*.qss", "../assets/*.png"]
+"soo_preclose_tester" = ["../themes/*.qss", "../assets/*.png"]


### PR DESCRIPTION
## Summary
- include QSS themes and PNG assets in package data

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pip wheel . -w dist` *(fails: could not install build deps due to network)*