### PR TITLE
Refactor widget styling to use global theme

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -150,83 +150,8 @@ class ExcelViewer(QWidget):
         self.sheet_name = None
         self.filtered_df = None
         
-        # Set dark theme for the entire widget
-        self.setStyleSheet("""
-            QWidget {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-            }
-            QLabel {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QGroupBox {
-                background-color: #333333;
-                border: 1px solid #555555;
-                border-radius: 4px;
-                margin-top: 1.5ex;
-                color: #e0e0e0;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                subcontrol-position: top center;
-                padding: 0 4px;
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 4px 8px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QPushButton:pressed {
-                background-color: #305580;
-            }
-            QPushButton:disabled {
-                background-color: #555555;
-                color: #888888;
-            }
-            QComboBox, QLineEdit, QSpinBox {
-                background-color: transparent;
-                color: #e0e0e0;
-                border: none;
-                border-radius: 3px;
-                padding: 2px 4px;
-            }
-            QComboBox:focus, QLineEdit:focus, QSpinBox:focus {
-                border: 1px solid #3a6ea5;
-            }
-            QComboBox::drop-down {
-                subcontrol-origin: padding;
-                subcontrol-position: top right;
-                width: 20px;
-                border-left: 1px solid #555555;
-            }
-            QComboBox QAbstractItemView {
-                background-color: #3c3c3c;
-                color: #e0e0e0;
-                selection-background-color: #3a6ea5;
-                selection-color: white;
-            }
-            QCheckBox {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QCheckBox::indicator {
-                width: 13px;
-                height: 13px;
-                border: 1px solid #555555;
-                background-color: #3c3c3c;
-            }
-            QCheckBox::indicator:checked {
-                background-color: #3a6ea5;
-            }
-        """)
+        # Store widgets that may need theme specific styling
+        self.toolbar = None
         
         # Default report configuration (SOO PreClose)
         self.report_config = {
@@ -258,123 +183,23 @@ class ExcelViewer(QWidget):
         
         self.table_view.setHorizontalHeader(self.horizontal_header)
         
-        # Set stylesheet for a dark theme that matches the application
-        self.table_view.setStyleSheet("""
-            QTableView {
-                background-color: #2d2d2d;
-                alternate-background-color: #333333;
-                color: #e0e0e0;
-                selection-background-color: #3a6ea5;
-                selection-color: #ffffff;
-                gridline-color: #4a4a4a;
-                border: 1px solid #4a4a4a;
-            }
-            QHeaderView::section {
-                background-color: #444444;
-                color: #e0e0e0;
-                padding: 4px;
-                border: 1px solid #555555;
-                font-weight: bold;
-            }
-            QTableView::item:selected {
-                background-color: #3a6ea5;
-                color: #ffffff;
-            }
-            QTableView::item:hover {
-                background-color: #424242;
-            }
-            QTableView QTableCornerButton::section {
-                background-color: #444444;
-                border: 1px solid #555555;
-            }
-        """)
+        # Clear table view stylesheet to inherit from application theme
+        self.table_view.setStyleSheet("")
         
         # Add table to main layout
         main_layout.addWidget(self.table_view)
         
         # Add status area
         self.status_label = QLabel("No data loaded")
-        self.status_label.setStyleSheet("color: #e0e0e0;")
         main_layout.addWidget(self.status_label)
         
     def create_toolbar(self, main_layout):
         """Create toolbar with data manipulation options"""
-        toolbar = QWidget()
-        toolbar.setStyleSheet("""
-            QWidget {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-            }
-            QGroupBox {
-                background-color: #333333;
-                border: 1px solid #555555;
-                border-radius: 4px;
-                margin-top: 1.5ex;
-                color: #e0e0e0;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                subcontrol-position: top center;
-                padding: 0 4px;
-                color: #e0e0e0;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 4px 8px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QPushButton:pressed {
-                background-color: #305580;
-            }
-            QPushButton:disabled {
-                background-color: #555555;
-                color: #888888;
-            }
-            QComboBox, QLineEdit, QSpinBox {
-                background-color: transparent;
-                color: #e0e0e0;
-                border: none;
-                border-radius: 3px;
-                padding: 2px 4px;
-            }
-            QComboBox:focus, QLineEdit:focus, QSpinBox:focus {
-                border: 1px solid #3a6ea5;
-            }
-            QComboBox::drop-down {
-                subcontrol-origin: padding;
-                subcontrol-position: top right;
-                width: 20px;
-                border-left: 1px solid #555555;
-            }
-            QComboBox QAbstractItemView {
-                background-color: #3c3c3c;
-                color: #e0e0e0;
-                selection-background-color: #3a6ea5;
-                selection-color: white;
-            }
-            QLabel {
-                color: #e0e0e0;
-            }
-            QCheckBox {
-                color: #e0e0e0;
-            }
-            QCheckBox::indicator {
-                width: 13px;
-                height: 13px;
-                border: 1px solid #555555;
-                background-color: #3c3c3c;
-            }
-            QCheckBox::indicator:checked {
-                background-color: #3a6ea5;
-            }
-        """)
+        self.toolbar = QWidget()
+        # Clear toolbar stylesheet so global theme can be applied
+        self.toolbar.setStyleSheet("")
         
-        toolbar_layout = QHBoxLayout(toolbar)
+        toolbar_layout = QHBoxLayout(self.toolbar)
         toolbar_layout.setContentsMargins(0, 0, 0, 5)
         
         # Sheet operations
@@ -473,8 +298,8 @@ class ExcelViewer(QWidget):
         toolbar_layout.addWidget(operations_group)
         toolbar_layout.addWidget(filter_group)
         toolbar_layout.addWidget(view_group)
-        
-        main_layout.addWidget(toolbar)
+
+        main_layout.addWidget(self.toolbar)
         
     def load_dataframe(self, df, sheet_name=None):
         """Load a dataframe into the viewer"""
@@ -1887,3 +1712,124 @@ class ExcelViewer(QWidget):
         # Disable all buttons
         self.update_button_states(False)
         self.clean_button.setEnabled(False)
+
+    def apply_widget_theme(self, theme: str):
+        """Apply theme-specific styling to the Excel viewer."""
+        if theme and theme.lower() == "dark":
+            widget_qss = """
+            QWidget {
+                background-color: #2d2d2d;
+                color: #e0e0e0;
+            }
+            QLabel {
+                color: #e0e0e0;
+                background: transparent;
+            }
+            QGroupBox {
+                background-color: #333333;
+                border: 1px solid #555555;
+                border-radius: 4px;
+                margin-top: 1.5ex;
+                color: #e0e0e0;
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                subcontrol-position: top center;
+                padding: 0 4px;
+                color: #e0e0e0;
+                background: transparent;
+            }
+            QPushButton {
+                background-color: #3a6ea5;
+                color: white;
+                border: 1px solid #555555;
+                border-radius: 3px;
+                padding: 4px 8px;
+            }
+            QPushButton:hover {
+                background-color: #4a7eb5;
+            }
+            QPushButton:pressed {
+                background-color: #305580;
+            }
+            QPushButton:disabled {
+                background-color: #555555;
+                color: #888888;
+            }
+            QComboBox, QLineEdit, QSpinBox {
+                background-color: transparent;
+                color: #e0e0e0;
+                border: none;
+                border-radius: 3px;
+                padding: 2px 4px;
+            }
+            QComboBox:focus, QLineEdit:focus, QSpinBox:focus {
+                border: 1px solid #3a6ea5;
+            }
+            QComboBox::drop-down {
+                subcontrol-origin: padding;
+                subcontrol-position: top right;
+                width: 20px;
+                border-left: 1px solid #555555;
+            }
+            QComboBox QAbstractItemView {
+                background-color: #3c3c3c;
+                color: #e0e0e0;
+                selection-background-color: #3a6ea5;
+                selection-color: white;
+            }
+            QCheckBox {
+                color: #e0e0e0;
+                background: transparent;
+            }
+            QCheckBox::indicator {
+                width: 13px;
+                height: 13px;
+                border: 1px solid #555555;
+                background-color: #3c3c3c;
+            }
+            QCheckBox::indicator:checked {
+                background-color: #3a6ea5;
+            }
+            """
+            table_qss = """
+            QTableView {
+                background-color: #2d2d2d;
+                alternate-background-color: #333333;
+                color: #e0e0e0;
+                selection-background-color: #3a6ea5;
+                selection-color: #ffffff;
+                gridline-color: #4a4a4a;
+                border: 1px solid #4a4a4a;
+            }
+            QHeaderView::section {
+                background-color: #444444;
+                color: #e0e0e0;
+                padding: 4px;
+                border: 1px solid #555555;
+                font-weight: bold;
+            }
+            QTableView::item:selected {
+                background-color: #3a6ea5;
+                color: #ffffff;
+            }
+            QTableView::item:hover {
+                background-color: #424242;
+            }
+            QTableView QTableCornerButton::section {
+                background-color: #444444;
+                border: 1px solid #555555;
+            }
+            """
+            toolbar_qss = widget_qss
+            self.setStyleSheet(widget_qss)
+            self.table_view.setStyleSheet(table_qss)
+            if self.toolbar:
+                self.toolbar.setStyleSheet(toolbar_qss)
+            self.status_label.setStyleSheet("color: #e0e0e0;")
+        else:
+            self.setStyleSheet("")
+            self.table_view.setStyleSheet("")
+            if self.toolbar:
+                self.toolbar.setStyleSheet("")
+            self.status_label.setStyleSheet("")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1456,7 +1456,7 @@ class MainWindow(QMainWindow):
         theme = self.config.get("ui", "theme")
         if not theme or theme.lower() == "system":
             QApplication.instance().setStyleSheet("")
-            return
+            theme = "system"
 
         themes_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes")
         if theme.lower() == "brand":
@@ -1468,3 +1468,9 @@ class MainWindow(QMainWindow):
                 QApplication.instance().setStyleSheet(f.read())
         else:
             QApplication.instance().setStyleSheet("")
+
+        # Propagate theme to child widgets
+        for widget in [getattr(self, attr, None) for attr in [
+            "excel_viewer", "sql_editor", "results_viewer"]]:
+            if widget and hasattr(widget, "apply_widget_theme"):
+                widget.apply_widget_theme(theme)

--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -149,49 +149,8 @@ class ResultsViewer(QWidget):
         self.table_view.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
         self.table_view.horizontalHeader().setStretchLastSection(True)
         
-        # Set stylesheet for better contrast
-        self.table_view.setStyleSheet("""
-            QTableView {
-                background-color: #2d2d2d;
-                alternate-background-color: #333333;
-                selection-background-color: #3a6ea5;
-                selection-color: #ffffff;
-                gridline-color: #4a4a4a;
-            }
-            QHeaderView::section {
-                background-color: #444444;
-                color: #e0e0e0;
-                padding: 4px;
-                border: 1px solid #555555;
-                font-weight: bold;
-            }
-            QLabel {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QComboBox {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-            QLineEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-        """)
+        # Let the global theme handle table styling
+        self.table_view.setStyleSheet("")
         
         main_layout.addWidget(self.table_view)
         
@@ -373,5 +332,54 @@ class ResultsViewer(QWidget):
         """Get the results as a pandas DataFrame"""
         if not self.results_data:
             return pd.DataFrame()
-            
+
         return pd.DataFrame(self.results_data)
+
+    def apply_widget_theme(self, theme: str):
+        """Apply theme-specific styling to the results viewer."""
+        if theme and theme.lower() == "dark":
+            qss = """
+            QTableView {
+                background-color: #2d2d2d;
+                alternate-background-color: #333333;
+                selection-background-color: #3a6ea5;
+                selection-color: #ffffff;
+                gridline-color: #4a4a4a;
+            }
+            QHeaderView::section {
+                background-color: #444444;
+                color: #e0e0e0;
+                padding: 4px;
+                border: 1px solid #555555;
+                font-weight: bold;
+            }
+            QLabel {
+                color: #e0e0e0;
+                background: transparent;
+            }
+            QPushButton {
+                background-color: #3a6ea5;
+                color: white;
+                border: 1px solid #555555;
+                border-radius: 3px;
+                padding: 6px 12px;
+            }
+            QPushButton:hover {
+                background-color: #4a7eb5;
+            }
+            QComboBox {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+                padding: 5px;
+            }
+            QLineEdit {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+                padding: 5px;
+            }
+            """
+            self.table_view.setStyleSheet(qss)
+        else:
+            self.table_view.setStyleSheet("")

--- a/src/ui/sql_editor.py
+++ b/src/ui/sql_editor.py
@@ -121,56 +121,8 @@ class SQLEditor(QWidget):
         # Add placeholder text
         self.editor.setPlaceholderText("Enter your SQL query here...")
         
-        # Set dark theme styling
-        self.setStyleSheet("""
-            QWidget {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-            }
-            QTextEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                font-family: Consolas, monospace;
-            }
-            QLabel {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QListWidget {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-            }
-            QListWidget::item {
-                padding: 4px;
-            }
-            QListWidget::item:selected {
-                background-color: #3a6ea5;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QComboBox {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-            QLineEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-        """)
+        # Let the global theme handle widget styling
+        self.setStyleSheet("")
         
         # Suggestions panel
         self.suggestions_panel = QWidget()
@@ -335,3 +287,59 @@ class SQLEditor(QWidget):
     def has_content(self):
         """Check if the editor has content"""
         return bool(self.get_text().strip())
+
+    def apply_widget_theme(self, theme: str):
+        """Apply theme-specific styling to the SQL editor."""
+        if theme and theme.lower() == "dark":
+            qss = """
+            QWidget {
+                background-color: #2d2d2d;
+                color: #e0e0e0;
+            }
+            QTextEdit {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+                font-family: Consolas, monospace;
+            }
+            QLabel {
+                color: #e0e0e0;
+                background: transparent;
+            }
+            QListWidget {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+            }
+            QListWidget::item {
+                padding: 4px;
+            }
+            QListWidget::item:selected {
+                background-color: #3a6ea5;
+            }
+            QPushButton {
+                background-color: #3a6ea5;
+                color: white;
+                border: 1px solid #555555;
+                border-radius: 3px;
+                padding: 6px 12px;
+            }
+            QPushButton:hover {
+                background-color: #4a7eb5;
+            }
+            QComboBox {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+                padding: 5px;
+            }
+            QLineEdit {
+                background-color: #333333;
+                color: #e0e0e0;
+                border: 1px solid #555555;
+                padding: 5px;
+            }
+            """
+            self.setStyleSheet(qss)
+        else:
+            self.setStyleSheet("")


### PR DESCRIPTION
## Summary
- remove hard-coded dark styles from `ExcelViewer`, `SQLEditor` and `ResultsViewer`
- add `apply_widget_theme` methods to handle optional dark styling
- call `apply_widget_theme` from `MainWindow.apply_theme`

## Testing
- `pytest -q` *(fails: command not found)*