### PR TITLE
Add brand widget styles

### DIFF
--- a/themes/brand.qss
+++ b/themes/brand.qss
@@ -21,3 +21,73 @@ QStatusBar {
 QHeaderView::section {
     background-color: #9ABDAA;
 }
+
+/* Group boxes keep a light background with branded border and text */
+QGroupBox {
+    background-color: #ffffff;
+    border: 1px solid #3B6E8F;
+    border-radius: 4px;
+    margin-top: 1.5ex;
+    color: #004B8D;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top center;
+    padding: 0 4px;
+    background: transparent;
+}
+
+/* Tool bars use a branded background and buttons */
+QToolBar {
+    background: #3B6E8F;
+    spacing: 4px;
+}
+QToolButton {
+    background-color: #279594;
+    color: white;
+    border-radius: 3px;
+    padding: 4px 6px;
+}
+QToolButton:hover {
+    background-color: #F58025;
+}
+QToolButton:pressed {
+    background-color: #76A240;
+}
+
+/* Tables keep a white background with subtle grid lines */
+QTableView {
+    background-color: #ffffff;
+    alternate-background-color: #f2f2f2;
+    gridline-color: #3B6E8F;
+    selection-background-color: #9ABDAA;
+    selection-color: #004B8D;
+}
+
+/* Tabs follow the brand palette */
+QTabWidget::pane {
+    border: 1px solid #3B6E8F;
+}
+QTabBar::tab {
+    background: #9ABDAA;
+    color: #004B8D;
+    padding: 4px 8px;
+    border: 1px solid #3B6E8F;
+    border-bottom: none;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QTabBar::tab:hover {
+    background: #F58025;
+}
+QTabBar::tab:selected {
+    background: #76A240;
+}
+QTabBar::tab:pressed {
+    background: #279594;
+}
+
+/* Buttons also get a pressed state */
+QPushButton:pressed {
+    background-color: #76A240;
+}


### PR DESCRIPTION
## Summary
- expand brand palette to group boxes, toolbars, tables and tabs
- implement hover/pressed states for brand buttons and tabs

## Testing
- `pytest -q` *(fails: command not found)*