### PR TITLE
Remove extra AppConfig import

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -37,7 +37,6 @@ class MainWindow(QMainWindow):
         self.setMinimumSize(1200, 800)
         
         # Load configuration
-        from src.utils.config import AppConfig
         self.config = AppConfig()
         
         # Set up logging


### PR DESCRIPTION
## Summary
- delete duplicate `AppConfig` import inside `MainWindow.__init__`

## Testing
- `pytest -q` *(fails: command not found)*