### PR TITLE
Fix account sort after add

### DIFF
--- a/src/ui/account_category_dialog.py
+++ b/src/ui/account_category_dialog.py
@@ -158,12 +158,12 @@ class AccountCategoryDialog(QDialog):
     def _add_account(self):
         account, ok = QInputDialog.getText(self, "Add Account", "Account number:")
         if ok and account:
+            checked = self._current_accounts()
             if account not in self.all_accounts:
                 self.all_accounts.append(account)
-                item = QListWidgetItem(account)
-                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
-                item.setCheckState(Qt.CheckState.Checked)
-                self.account_list.addItem(item)
+                self.all_accounts.sort()
+                checked.append(account)
+                self._populate_account_list(checked)
             self._accounts_changed()
 
     def _add_category(self):

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -234,6 +234,21 @@ class TestAccountCategoryDialog(unittest.TestCase):
             self.assertTrue(item.flags() & Qt.ItemFlag.ItemIsUserCheckable)
             self.assertEqual(item.checkState(), Qt.CheckState.Unchecked)
 
+    def test_accounts_sorted_after_add(self):
+        accounts = ['2222', '3333']
+        config = DummyConfig()
+        dialog = self.Dialog(config, 'Test', accounts)
+        from PyQt6.QtWidgets import QInputDialog
+
+        def fake_get_text(*args, **kwargs):
+            return '1111', True
+
+        QInputDialog.getText = staticmethod(fake_get_text)
+        dialog._add_account()
+
+        texts = [dialog.account_list.item(i).text() for i in range(dialog.account_list.count())]
+        self.assertEqual(texts, sorted(accounts + ['1111']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- sort all accounts after adding a new one
- refresh the account list after adding
- test that added accounts are ordered alphabetically

## Testing
- `python -m pytest tests/test_account_categories.py::TestAccountCategoryDialog::test_accounts_sorted_after_add -q` *(fails: No module named pytest)*