### PR TITLE
Improve account extraction from Excel

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1216,10 +1216,11 @@ class MainWindow(QMainWindow):
             return []
 
         patterns = [
-            r"(\d{4}-\d{4})",
-            r"(\d{5}-\d{3})",
-            r"(\d{3}-\d{5})",
-            r"(\d{4}-\d{5})",
+            r"(\d{4}-?\d{4})",
+            r"(\d{5}-?\d{3})",
+            r"(\d{3}-?\d{5})",
+            r"(\d{4}-?\d{5})",
+            r"(\d{7,8})",
         ]
         accounts = set()
         try:

--- a/tests/fixtures/excel_data_nodash.csv
+++ b/tests/fixtures/excel_data_nodash.csv
@@ -1,0 +1,3 @@
+Center,CAReportName,Amount
+1,12345678,100
+2,87654321,50

--- a/tests/test_gather_accounts_nodash.py
+++ b/tests/test_gather_accounts_nodash.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import pandas as pd
+from src.analyzer.excel_analyzer import ExcelAnalyzer
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+def patch_qt_modules():
+    """Patch PyQt6 and related UI modules so main_window can be imported."""
+    widgets = types.ModuleType('PyQt6.QtWidgets')
+    widget_attrs = [
+        "QMainWindow", "QTabWidget", "QApplication", "QWidget", "QVBoxLayout",
+        "QHBoxLayout", "QLabel", "QPushButton", "QFileDialog", "QMessageBox",
+        "QStatusBar", "QMenuBar", "QMenu", "QToolBar", "QSplitter",
+        "QComboBox", "QLineEdit", "QProgressDialog", "QDialog", "QListWidget",
+        "QDialogButtonBox"
+    ]
+    for attr in widget_attrs:
+        setattr(widgets, attr, type(attr, (), {}))
+
+    core = types.ModuleType('PyQt6.QtCore')
+    for attr in ["Qt", "QSize"]:
+        setattr(core, attr, type(attr, (), {}))
+
+    gui = types.ModuleType('PyQt6.QtGui')
+    for attr in ["QIcon", "QAction", "QFont"]:
+        setattr(gui, attr, type(attr, (), {}))
+
+    sys.modules.setdefault('PyQt6', types.ModuleType('PyQt6'))
+    sys.modules['PyQt6.QtWidgets'] = widgets
+    sys.modules['PyQt6.QtCore'] = core
+    sys.modules['PyQt6.QtGui'] = gui
+
+    qta = types.ModuleType('qtawesome')
+    qta.icon = lambda *args, **kwargs: None
+    sys.modules['qtawesome'] = qta
+
+    for name in [
+        'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
+        'src.ui.comparison_view', 'src.ui.settings_dialog',
+        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+    ]:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+
+class TestGatherAccountsNoDash(unittest.TestCase):
+    def setUp(self):
+        patch_qt_modules()
+        file_path = os.path.join(FIXTURES, 'excel_data_nodash.csv')
+        df = pd.read_csv(file_path)
+        self.analyzer = ExcelAnalyzer(file_path)
+        sheet = 'Sheet1'
+        self.analyzer.sheet_names = [sheet]
+        self.analyzer.sheet_data[sheet] = {
+            'dataframe': df,
+            'header_indexes': [0]
+        }
+
+    def test_gather_accounts_no_dash(self):
+        from src.ui.main_window import MainWindow
+
+        window = MainWindow.__new__(MainWindow)
+        window.excel_analyzer = self.analyzer
+        window.logger = MagicMock()
+
+        accounts = window._gather_accounts_from_excel()
+        self.assertEqual(accounts, ['12345678', '87654321'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow account numbers without hyphens when scanning Excel files
- add fixture and unit test for numbers without dashes

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*