### PR TITLE
Fix account column detection

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1467,6 +1467,17 @@ class MainWindow(QMainWindow):
                 for col in key_cols:
                     excel_vals = excel_df[col].dropna().unique()
                     filtered_sql_df = filtered_sql_df[filtered_sql_df[col].isin(excel_vals)]
+
+            # Apply account categories and formulas to SQL rows before comparison
+            report_type = self.report_selector.currentText()
+            categories = self.config.get_account_categories(report_type)
+            formulas = self.config.get_account_formulas(report_type)
+            if categories:
+                from src.utils.account_categories import CategoryCalculator
+                calc = CategoryCalculator(categories, formulas)
+                sql_rows = filtered_sql_df.to_dict(orient="records")
+                filtered_sql_df = pd.DataFrame(calc.compute(sql_rows))
+
             # Generate detailed DataFrame
             df = self.comparison_engine.generate_detailed_comparison_dataframe(sheet_name, excel_df, filtered_sql_df)
             all_dfs.append(df)

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -213,6 +213,21 @@ class TestCategoryCalculator(unittest.TestCase):
         net = next(r for r in result if r['CAReportName'] == 'Net')
         self.assertEqual(net['Amount'], -50)
 
+    def test_compute_detects_account_column(self):
+        rows = [
+            {'Center': 1, 'Account': '1234-5678', 'Amount': -100},
+            {'Center': 2, 'Account': '9999-0000', 'Amount': 50},
+        ]
+        calc = CategoryCalculator(self.categories, self.formulas)
+        result = calc.compute(rows)
+        self.assertEqual(len(result), len(rows) + 3)
+        cat_a = next(r for r in result if r['Account'] == 'CatA')
+        self.assertEqual(cat_a['Amount'], -100)
+        cat_b = next(r for r in result if r['Account'] == 'CatB')
+        self.assertEqual(cat_b['Amount'], 50)
+        net = next(r for r in result if r['Account'] == 'Net')
+        self.assertEqual(net['Amount'], -50)
+
 
 class TestAccountCategoryDialog(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- auto-detect the account column in `CategoryCalculator`
- test detection using Account column
- include category calculations when exporting detailed results

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*