### PR TITLE
Fix formula rows export

### DIFF
--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -213,6 +213,21 @@ class TestCategoryCalculator(unittest.TestCase):
         net = next(r for r in result if r['CAReportName'] == 'Net')
         self.assertEqual(net['Amount'], -50)
 
+    def test_compute_detects_account_column(self):
+        rows = [
+            {'Center': 1, 'Account': '1234-5678', 'Amount': -100},
+            {'Center': 2, 'Account': '9999-0000', 'Amount': 50},
+        ]
+        calc = CategoryCalculator(self.categories, self.formulas)
+        result = calc.compute(rows)
+        self.assertEqual(len(result), len(rows) + 3)
+        cat_a = next(r for r in result if r['Account'] == 'CatA')
+        self.assertEqual(cat_a['Amount'], -100)
+        cat_b = next(r for r in result if r['Account'] == 'CatB')
+        self.assertEqual(cat_b['Amount'], 50)
+        net = next(r for r in result if r['Account'] == 'Net')
+        self.assertEqual(net['Amount'], -50)
+
 
 class TestAccountCategoryDialog(unittest.TestCase):
     def setUp(self):

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import pandas as pd
 from src.analyzer.comparison_engine import ComparisonEngine
+from src.utils.account_categories import CategoryCalculator
 
 FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
 
@@ -26,6 +27,18 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         self.engine.set_sign_flip_accounts(['1234-5678'])
         df = self.engine.generate_detailed_comparison_dataframe('Sheet1', self.excel_df, sql_mod)
         self.assertIn('Does Not Match', df['Result'].values)
+
+    def test_detailed_dataframe_includes_formula_rows(self):
+        categories = {
+            'CatA': ['1234-5678'],
+        }
+        formulas = {
+            'Net': 'CatA'
+        }
+        calc = CategoryCalculator(categories, formulas)
+        sql_mod = pd.DataFrame(calc.compute(self.sql_df.to_dict(orient='records')))
+        df = self.engine.generate_detailed_comparison_dataframe('Sheet1', self.excel_df, sql_mod)
+        self.assertIn('Net', df['CAReport Name'].values)
 
     def test_identify_account_discrepancies(self):
         discrepancies = self.engine.identify_account_discrepancies(self.excel_df, self.sql_df)


### PR DESCRIPTION
## Summary
- retain category and formula rows when exporting detailed results
- apply account categories during export filtering
- test that formula rows appear in the detailed dataframe

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*