### PR TITLE
Add group-based category calculations

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1475,7 +1475,8 @@ class MainWindow(QMainWindow):
                 categories = self.config.get_account_categories(report_type)
                 formulas = self.config.get_account_formulas(report_type)
                 if categories:
-                    calc = CategoryCalculator(categories, formulas)
+                    group_col = "Center" if "Center" in filtered_sql_df.columns else None
+                    calc = CategoryCalculator(categories, formulas, group_column=group_col)
                     sql_rows = filtered_sql_df.to_dict(orient="records")
                     filtered_sql_df = pd.DataFrame(calc.compute(sql_rows))
 
@@ -1540,7 +1541,8 @@ class MainWindow(QMainWindow):
                 categories = self.config.get_account_categories(report_type)
                 formulas = self.config.get_account_formulas(report_type)
                 if categories:
-                    calc = CategoryCalculator(categories, formulas)
+                    group_col = "Center" if "Center" in filtered_sql_df.columns else None
+                    calc = CategoryCalculator(categories, formulas, group_column=group_col)
                     sql_rows = filtered_sql_df.to_dict(orient="records")
                     filtered_sql_df = pd.DataFrame(calc.compute(sql_rows))
 

--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -210,7 +210,11 @@ class ResultsViewer(QWidget):
                 categories = parent.config.get_account_categories(report_type)
                 formulas = parent.config.get_account_formulas(report_type)
                 if categories:
-                    calc = CategoryCalculator(categories, formulas)
+                    group_col = None
+                    if self.results_data and isinstance(self.results_data[0], dict):
+                        if "Center" in self.results_data[0]:
+                            group_col = "Center"
+                    calc = CategoryCalculator(categories, formulas, group_column=group_col)
                     self.results_data = calc.compute(list(self.results_data))
         
         # If columns not provided, try to get them from the first row

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -228,6 +228,21 @@ class TestCategoryCalculator(unittest.TestCase):
         net = next(r for r in result if r['Account'] == 'Net')
         self.assertEqual(net['Amount'], -50)
 
+    def test_grouped_totals_and_formulas(self):
+        calc = CategoryCalculator(self.categories, self.formulas, group_column="Center")
+        result = calc.compute(list(self.rows))
+        self.assertEqual(len(result), len(self.rows) + 6)
+
+        cat_a_c1 = next(r for r in result if r['CAReportName'] == 'CatA' and r['Center'] == 1)
+        self.assertEqual(cat_a_c1['Amount'], -100)
+        cat_b_c2 = next(r for r in result if r['CAReportName'] == 'CatB' and r['Center'] == 2)
+        self.assertEqual(cat_b_c2['Amount'], 50)
+
+        net_c1 = next(r for r in result if r['CAReportName'] == 'Net' and r['Center'] == 1)
+        self.assertEqual(net_c1['Amount'], -100)
+        net_c2 = next(r for r in result if r['CAReportName'] == 'Net' and r['Center'] == 2)
+        self.assertEqual(net_c2['Amount'], 50)
+
 
 class TestAccountCategoryDialog(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- support grouping when computing account categories
- propagate grouping through viewer and exports
- test grouped totals and formulas

## Testing
- `pytest -q` *(fails: No module named pytest)*