### PR TITLE
Handle Decimal totals in account categories

### DIFF
--- a/src/utils/account_categories.py
+++ b/src/utils/account_categories.py
@@ -93,8 +93,8 @@ class CategoryCalculator:
         else:
             groups = [None]
 
-        totals: Dict[Any, Dict[str, Dict[str, float]]] = {
-            g: {name: {col: 0.0 for col in numeric_cols} for name in self.categories}
+        totals: Dict[Any, Dict[str, Dict[str, Decimal]]] = {
+            g: {name: {col: Decimal("0") for col in numeric_cols} for name in self.categories}
             for g in groups
         }
 
@@ -106,7 +106,10 @@ class CategoryCalculator:
                     for col in numeric_cols:
                         val = row.get(col)
                         if isinstance(val, (int, float, Decimal)) and not isinstance(val, bool):
-                            totals[group_val][name][col] += float(val)
+                            if isinstance(val, Decimal):
+                                totals[group_val][name][col] += val
+                            else:
+                                totals[group_val][name][col] += Decimal(str(val))
 
         for g in groups:
             for name in self.categories:
@@ -118,7 +121,7 @@ class CategoryCalculator:
             for form_name, expr in self.formulas.items():
                 values = {}
                 for col in numeric_cols:
-                    local = {k: totals[g].get(k, {}).get(col, 0.0) for k in self.categories}
+                    local = {k: totals[g].get(k, {}).get(col, Decimal("0")) for k in self.categories}
                     try:
                         values[col] = eval(expr, {}, local)
                     except Exception:

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -312,6 +312,37 @@ class TestCategoryCalculator(unittest.TestCase):
         net_c2 = next(r for r in result if r['CAReportName'] == 'Net' and r['Center'] == 2)
         self.assertEqual(net_c2['Amount'], 7)
 
+    def test_all_decimal_amounts_grouped(self):
+        rows = [
+            {'Center': 1, 'CAReportName': '1234-5678', 'Amount': Decimal('1')},
+            {'Center': 1, 'CAReportName': '9999-0000', 'Amount': Decimal('2')},
+            {'Center': 2, 'CAReportName': '1234-5678', 'Amount': Decimal('3')},
+            {'Center': 2, 'CAReportName': '9999-0000', 'Amount': Decimal('4')},
+        ]
+
+        calc = CategoryCalculator(self.categories, self.formulas, group_column="Center")
+        result = calc.compute(rows)
+
+        self.assertEqual(len(result), len(rows) + 6)
+
+        cat_a_c1 = next(r for r in result if r['CAReportName'] == 'CatA' and r['Center'] == 1)
+        self.assertEqual(cat_a_c1['Amount'], 1)
+
+        cat_b_c1 = next(r for r in result if r['CAReportName'] == 'CatB' and r['Center'] == 1)
+        self.assertEqual(cat_b_c1['Amount'], 2)
+
+        net_c1 = next(r for r in result if r['CAReportName'] == 'Net' and r['Center'] == 1)
+        self.assertEqual(net_c1['Amount'], 3)
+
+        cat_a_c2 = next(r for r in result if r['CAReportName'] == 'CatA' and r['Center'] == 2)
+        self.assertEqual(cat_a_c2['Amount'], 3)
+
+        cat_b_c2 = next(r for r in result if r['CAReportName'] == 'CatB' and r['Center'] == 2)
+        self.assertEqual(cat_b_c2['Amount'], 4)
+
+        net_c2 = next(r for r in result if r['CAReportName'] == 'Net' and r['Center'] == 2)
+        self.assertEqual(net_c2['Amount'], 7)
+
 
 class TestAccountCategoryDialog(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- support `decimal.Decimal` for category computations
- add regression test for decimal amounts per center

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*