### PR TITLE
Fix group column handling in CategoryCalculator

### DIFF
--- a/src/utils/account_categories.py
+++ b/src/utils/account_categories.py
@@ -66,10 +66,13 @@ class CategoryCalculator:
         for row in rows:
             for key, val in row.items():
                 if key == self.group_column:
+                    # never treat the grouping column as numeric
                     continue
                 if isinstance(val, (int, float, Decimal)) and not isinstance(val, bool):
                     if key not in numeric_cols:
                         numeric_cols.append(key)
+        if self.group_column and self.group_column in numeric_cols:
+            numeric_cols.remove(self.group_column)
         return numeric_cols
 
     def compute(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -229,6 +229,11 @@ class TestCategoryCalculator(unittest.TestCase):
         net = next(r for r in result if r['Account'] == 'Net')
         self.assertEqual(net['Amount'], -50)
 
+    def test_numeric_columns_skip_group_column(self):
+        calc = CategoryCalculator(self.categories, self.formulas, group_column="Center")
+        numeric = calc._numeric_columns(self.rows)
+        self.assertEqual(numeric, ['Amount'])
+
     def test_grouped_totals_and_formulas(self):
         calc = CategoryCalculator(self.categories, self.formulas, group_column="Center")
         result = calc.compute(list(self.rows))


### PR DESCRIPTION
## Summary
- make `_numeric_columns` never treat the grouping column as numeric
- add test verifying group column is skipped when computing numeric columns

## Testing
- `pytest tests/test_account_categories.py::TestCategoryCalculator::test_numeric_columns_skip_group_column -q` *(fails: pytest not found)*