### PR TITLE
Fix account extraction and formula evaluation

### DIFF
--- a/src/analyzer/sign_flip.py
+++ b/src/analyzer/sign_flip.py
@@ -3,14 +3,17 @@ from typing import Iterable, Any
 
 
 def _normalize_account(account: Any) -> str:
+    """Return digits-only account identifier."""
     acct_str = str(account).strip()
-    match = re.search(r"\d{4}-\d{4}", acct_str)
-    return match.group(0) if match else acct_str
+    if not acct_str:
+        return ""
+    digits = re.findall(r"\d", acct_str)
+    return "".join(digits)
 
 
 def should_flip(account: Any, sign_flip_accounts: Iterable[str]) -> bool:
     """Return True if the value should have its sign flipped."""
-    accounts = {str(a).strip() for a in sign_flip_accounts or []}
+    accounts = {_normalize_account(a) for a in sign_flip_accounts or []}
     return _normalize_account(account) in accounts
 
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1430,7 +1430,7 @@ class MainWindow(QMainWindow):
                     self.excel_analyzer.analyze_sheet(sheet)
 
                 sheet_info = self.excel_analyzer.sheet_data[sheet]
-                df = sheet_info["dataframe"]
+                df = sheet_info.get("cleaned_dataframe") or sheet_info["dataframe"]
 
                 # If the dataframe has numeric column names, rebuild headers
                 cols_are_numeric = all(

--- a/src/utils/account_categories.py
+++ b/src/utils/account_categories.py
@@ -108,7 +108,7 @@ class CategoryCalculator:
             r"(\d{5}-?\d{3})",
             r"(\d{3}-?\d{5})",
             r"(\d{4}-?\d{5})",
-            r"(\d{7,8})",
+            r"(\d{7,10})",
         ]
 
         for pat in patterns:


### PR DESCRIPTION
## Summary
- normalize account numbers before sign flip checks
- expand account matching patterns
- prefer cleaned data when gathering accounts

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*