### PR TITLE
Fix account extraction logic

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1445,11 +1445,47 @@ class MainWindow(QMainWindow):
                     if headers:
                         df.columns = headers
 
-                for col in df.columns:
-                    col_data = df[col].astype(str)
-                    for val in col_data:
-                        for pat in patterns:
-                            accounts.update(re.findall(pat, val))
+                # Determine which column likely contains account numbers
+                account_col = None
+                known = [
+                    "CAReportName",
+                    "Account",
+                    "Account Number",
+                    "AccountNumber",
+                    "Acct",
+                ]
+                for cand in known:
+                    if cand in df.columns:
+                        account_col = cand
+                        break
+
+                # Look for any column name containing "account" if we didn't
+                # match one of the common headers
+                if not account_col:
+                    for col in df.columns:
+                        if "account" in str(col).lower():
+                            account_col = col
+                            break
+
+                # If headers haven't been imported yet, fall back to the
+                # position used by the Extract SQL feature (second column,
+                # or third if Sheet_Name is present)
+                if account_col is None:
+                    fallback_idx = 1
+                    if (
+                        len(df.columns) > 2
+                        and str(df.columns[0]).strip() == "Sheet_Name"
+                    ):
+                        fallback_idx = 2
+                    if len(df.columns) > fallback_idx:
+                        account_col = df.columns[fallback_idx]
+                    else:
+                        continue
+
+                col_data = df[account_col].astype(str)
+                for val in col_data:
+                    for pat in patterns:
+                        accounts.update(re.findall(pat, val))
         except Exception as e:
             self.logger.error(f"Failed to extract accounts: {e}")
 

--- a/src/utils/account_patterns.py
+++ b/src/utils/account_patterns.py
@@ -1,7 +1,15 @@
+"""Regular expressions for extracting account numbers from text."""
+
+# Accounts are expected to be in the format ``XXXX-XXXX`` where the prefix may
+# optionally start with a single letter.  Examples include ``6101-6001`` and
+# ``R101-0000``.  Previous patterns attempted to match many other digit
+# combinations which resulted in unrelated numeric values being captured when
+# scanning spreadsheets.  The patterns below focus only on the supported
+# account formats.
+
 ACCOUNT_PATTERNS = [
-    r'(\d{4}-?\d{4})',
-    r'(\d{5}-?\d{3})',
-    r'(\d{3}-?\d{5})',
-    r'(\d{4}-?\d{5})',
-    r'(\d{7,10})',
+    # Letter prefix followed by three digits and a four digit suffix
+    r"([A-Za-z]\d{3}-\d{4})",
+    # Four digit prefix followed by four digit suffix
+    r"(\d{4}-\d{4})",
 ]


### PR DESCRIPTION
## Summary
- refine `ACCOUNT_PATTERNS` to only match valid `XXXX-XXXX` formats
- restrict account gathering to the likely account column in each sheet
- add fallback to the 2nd column when headers are missing

## Testing
- `python -m py_compile src/utils/account_patterns.py src/ui/main_window.py`
- `pytest -q` *(fails: command not found)*