### PR TITLE
Introduce base stylesheet for unified layout

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1720,127 +1720,31 @@ class ExcelViewer(QWidget):
         self.clean_button.setEnabled(False)
 
     def apply_widget_theme(self, theme: str):
-        """Apply theme-specific styling to the Excel viewer."""
+        """Apply base style and theme colors to the Excel viewer."""
         self.current_theme = theme or "system"
-        if theme and theme.lower() == "dark":
-            widget_qss = """
-            QWidget {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-            }
-            QLabel {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QGroupBox {
-                background-color: #333333;
-                border: 1px solid #555555;
-                border-radius: 4px;
-                margin-top: 1.5ex;
-                color: #e0e0e0;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                subcontrol-position: top center;
-                padding: 0 4px;
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 4px 8px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QPushButton:pressed {
-                background-color: #305580;
-            }
-            QPushButton:disabled {
-                background-color: #555555;
-                color: #888888;
-            }
-            QComboBox, QLineEdit, QSpinBox {
-                background-color: transparent;
-                color: #e0e0e0;
-                border: none;
-                border-radius: 3px;
-                padding: 2px 4px;
-            }
-            QComboBox:focus, QLineEdit:focus, QSpinBox:focus {
-                border: 1px solid #3a6ea5;
-            }
-            QComboBox::drop-down {
-                subcontrol-origin: padding;
-                subcontrol-position: top right;
-                width: 20px;
-                border-left: 1px solid #555555;
-            }
-            QComboBox QAbstractItemView {
-                background-color: #3c3c3c;
-                color: #e0e0e0;
-                selection-background-color: #3a6ea5;
-                selection-color: white;
-            }
-            QCheckBox {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QCheckBox::indicator {
-                width: 13px;
-                height: 13px;
-                border: 1px solid #555555;
-                background-color: #3c3c3c;
-            }
-            QCheckBox::indicator:checked {
-                background-color: #3a6ea5;
-            }
-            """
-            table_qss = """
-            QTableView {
-                background-color: #2d2d2d;
-                alternate-background-color: #333333;
-                color: #e0e0e0;
-                selection-background-color: #3a6ea5;
-                selection-color: #ffffff;
-                gridline-color: #4a4a4a;
-                border: 1px solid #4a4a4a;
-            }
-            QHeaderView::section {
-                background-color: #444444;
-                color: #e0e0e0;
-                padding: 4px;
-                border: 1px solid #555555;
-                font-weight: bold;
-            }
-            QTableView::item:selected {
-                background-color: #3a6ea5;
-                color: #ffffff;
-            }
-            QTableView::item:hover {
-                background-color: #424242;
-            }
-            QTableView QTableCornerButton::section {
-                background-color: #444444;
-                border: 1px solid #555555;
-            }
-            """
-            toolbar_qss = widget_qss
-            self.setStyleSheet(widget_qss)
-            self.table_view.setStyleSheet(table_qss)
-            if self.toolbar:
-                self.toolbar.setStyleSheet(toolbar_qss)
-            self.status_label.setStyleSheet("color: #e0e0e0;")
-        else:
-            self.setStyleSheet("")
-            self.table_view.setStyleSheet("")
-            if self.toolbar:
-                self.toolbar.setStyleSheet("")
-            self.status_label.setStyleSheet("")
+
+        themes_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes"
+        )
+
+        def load_qss(name: str) -> str:
+            path = os.path.join(themes_dir, name)
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+            return ""
+
+        qss = load_qss("base.qss")
+        theme_lower = (theme or "").lower()
+        if theme_lower and theme_lower != "system":
+            qss += load_qss(f"{theme_lower}.qss")
+
+        # Clear per-widget styles so the loaded QSS can apply globally
+        self.setStyleSheet(qss)
+        self.table_view.setStyleSheet(qss)
+        if self.toolbar:
+            self.toolbar.setStyleSheet(qss)
 
         # Update the table model with the new theme
         if hasattr(self, "model") and self.model:
-            self.model.set_dark_theme(self.current_theme.lower() == "dark")
+            self.model.set_dark_theme(theme_lower == "dark")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1866,22 +1866,30 @@ class MainWindow(QMainWindow):
     def apply_theme(self):
         """Apply application-wide stylesheet based on configuration"""
         theme = self.config.get("ui", "theme")
-        if not theme or theme.lower() == "system":
-            QApplication.instance().setStyleSheet("")
-            theme = "system"
 
         themes_dir = os.path.join(
             os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes"
         )
-        if theme.lower() == "brand":
-            theme_file = os.path.join(themes_dir, "brand.qss")
-        else:
-            theme_file = os.path.join(themes_dir, f"{theme.lower()}.qss")
-        if os.path.exists(theme_file):
-            with open(theme_file, "r", encoding="utf-8") as f:
-                QApplication.instance().setStyleSheet(f.read())
-        else:
-            QApplication.instance().setStyleSheet("")
+
+        def load_qss(name: str) -> str:
+            path = os.path.join(themes_dir, name)
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+            return ""
+
+        style = load_qss("base.qss")
+
+        theme_lower = (theme or "").lower()
+        if theme_lower and theme_lower != "system":
+            if theme_lower == "brand":
+                style += load_qss("brand.qss")
+            else:
+                style += load_qss(f"{theme_lower}.qss")
+
+        QApplication.instance().setStyleSheet(style)
+        if not theme:
+            theme = "system"
 
         # Propagate theme to child widgets
         for widget in [

--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -415,50 +415,21 @@ class ResultsViewer(QWidget):
         return pd.DataFrame(self.results_data)
 
     def apply_widget_theme(self, theme: str):
-        """Apply theme-specific styling to the results viewer."""
-        if theme and theme.lower() == "dark":
-            qss = """
-            QTableView {
-                background-color: #2d2d2d;
-                alternate-background-color: #333333;
-                selection-background-color: #3a6ea5;
-                selection-color: #ffffff;
-                gridline-color: #4a4a4a;
-            }
-            QHeaderView::section {
-                background-color: #444444;
-                color: #e0e0e0;
-                padding: 4px;
-                border: 1px solid #555555;
-                font-weight: bold;
-            }
-            QLabel {
-                color: #e0e0e0;
-                background: transparent;
-            }
-            QPushButton {
-                background-color: #3a6ea5;
-                color: white;
-                border: 1px solid #555555;
-                border-radius: 3px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #4a7eb5;
-            }
-            QComboBox {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-            QLineEdit {
-                background-color: #333333;
-                color: #e0e0e0;
-                border: 1px solid #555555;
-                padding: 5px;
-            }
-            """
-            self.table_view.setStyleSheet(qss)
-        else:
-            self.table_view.setStyleSheet("")
+        """Apply base style and theme colors to the results viewer."""
+        themes_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "themes"
+        )
+
+        def load_qss(name: str) -> str:
+            path = os.path.join(themes_dir, name)
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+            return ""
+
+        qss = load_qss("base.qss")
+        theme_lower = (theme or "").lower()
+        if theme_lower and theme_lower != "system":
+            qss += load_qss(f"{theme_lower}.qss")
+
+        self.table_view.setStyleSheet(qss)

--- a/themes/base.qss
+++ b/themes/base.qss
@@ -1,0 +1,48 @@
+/* Base layout and spacing shared by all themes */
+
+QWidget {
+    font-family: "Proxima Nova", Arial, sans-serif;
+}
+
+QGroupBox {
+    border: 1px solid;
+    border-radius: 4px;
+    margin-top: 1.5ex;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top center;
+    padding: 0 4px;
+}
+
+QToolBar {
+    spacing: 4px;
+}
+
+QToolButton, QPushButton {
+    border-radius: 3px;
+    padding: 4px 6px;
+}
+
+QHeaderView::section {
+    padding: 4px;
+    font-weight: bold;
+}
+
+QTableView {
+    alternate-background-color: palette(alternate-base);
+    gridline-color: palette(mid);
+}
+
+QTabWidget::pane {
+    border: 1px solid;
+}
+
+QTabBar::tab {
+    padding: 4px 8px;
+    border: 1px solid;
+    border-bottom: none;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- define `themes/base.qss` for common layout and spacing
- update Excel and Results viewer theming to use the base stylesheet
- apply base stylesheet globally in `MainWindow.apply_theme`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*