### PR TITLE
Unify theme qss files

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,32 @@
+# Theme Color Palettes
+
+The Qt style sheets in this directory define three color themes for the
+application.  Each theme uses the same QSS selectors so only the colors
+differ.
+
+## Light Theme
+- **Background:** `#ffffff`
+- **Text:** `#000000`
+- **Button:** `#f0f0f0`
+- **Menu/Status Bar:** `#f0f0f0`
+- **Header Section:** `#dcdcdc`
+- **Tool Button:** `#dcdcdc`
+- **Selection:** `#cce8ff`
+
+## Dark Theme
+- **Background:** `#2d2d2d`
+- **Text:** `#e0e0e0`
+- **Button:** `#3a6ea5`
+- **Menu/Status Bar:** `#333333`
+- **Header Section:** `#444444`
+- **Tool Button:** `#3a6ea5`
+- **Selection:** `#3a6ea5`
+
+## Brand Theme
+- **Background:** `#ffffff`
+- **Text:** `#004B8D`
+- **Primary Accent:** `#F58025`
+- **Menu Bar:** `#3B6E8F`
+- **Status Bar:** `#76A240`
+- **Header Section:** `#004B8D`
+- **Selection:** `#9ABDAA`

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -2,7 +2,71 @@ QWidget {
     background-color: #2d2d2d;
     color: #e0e0e0;
 }
+
 QPushButton {
     background-color: #3a6ea5;
     color: white;
+}
+
+QMenuBar {
+    background-color: #333333;
+    color: #e0e0e0;
+}
+
+QStatusBar {
+    background-color: #333333;
+    color: #e0e0e0;
+}
+
+QHeaderView::section {
+    background-color: #444444;
+    color: #e0e0e0;
+}
+
+/* Group boxes keep a dark background with light text */
+QGroupBox {
+    background-color: #2d2d2d;
+    color: #e0e0e0;
+}
+QGroupBox::title {
+    background: transparent;
+}
+
+/* Tool bars use a dark background */
+QToolBar {
+    background: #333333;
+}
+QToolButton {
+    background-color: #3a6ea5;
+    color: white;
+}
+QToolButton:pressed {
+    background-color: #5d9cec;
+}
+
+/* Tables keep a dark background with subtle grid lines */
+QTableView {
+    background-color: #2d2d2d;
+    alternate-background-color: #383838;
+    gridline-color: #444444;
+    color: #e0e0e0;
+    selection-background-color: #3a6ea5;
+    selection-color: #ffffff;
+}
+
+/* Tabs follow the dark palette */
+QTabBar::tab {
+    background: #3a6ea5;
+    color: white;
+}
+QTabBar::tab:selected {
+    background: #274d78;
+}
+QTabBar::tab:pressed {
+    background: #5d9cec;
+}
+
+/* Buttons also get a pressed state */
+QPushButton:pressed {
+    background-color: #274d78;
 }

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -2,3 +2,71 @@ QWidget {
     background-color: #ffffff;
     color: #000000;
 }
+
+QPushButton {
+    background-color: #f0f0f0;
+    color: #000000;
+}
+
+QMenuBar {
+    background-color: #f0f0f0;
+    color: #000000;
+}
+
+QStatusBar {
+    background-color: #f0f0f0;
+    color: #000000;
+}
+
+QHeaderView::section {
+    background-color: #dcdcdc;
+    color: #000000;
+}
+
+/* Group boxes keep a white background with black text */
+QGroupBox {
+    background-color: #ffffff;
+    color: #000000;
+}
+QGroupBox::title {
+    background: transparent;
+}
+
+/* Tool bars use the same light background */
+QToolBar {
+    background: #f0f0f0;
+}
+QToolButton {
+    background-color: #dcdcdc;
+    color: #000000;
+}
+QToolButton:pressed {
+    background-color: #c0c0c0;
+}
+
+/* Tables keep a white background with subtle grid lines */
+QTableView {
+    background-color: #ffffff;
+    alternate-background-color: #f9f9f9;
+    gridline-color: #dcdcdc;
+    color: #000000;
+    selection-background-color: #cce8ff;
+    selection-color: #000000;
+}
+
+/* Tabs follow the light palette */
+QTabBar::tab {
+    background: #f0f0f0;
+    color: #000000;
+}
+QTabBar::tab:selected {
+    background: #dcdcdc;
+}
+QTabBar::tab:pressed {
+    background: #c0c0c0;
+}
+
+/* Buttons also get a pressed state */
+QPushButton:pressed {
+    background-color: #dcdcdc;
+}


### PR DESCRIPTION
## Summary
- expand light and dark themes to use same selectors
- keep brand theme structure
- document color palettes for all themes

## Testing
- `pytest -q` *(fails: command not found)*