### PR TITLE
Fix missing os import

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import os
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,


### PR DESCRIPTION
## Summary
- import `os` in `src/ui/results_viewer.py`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*