### PR TITLE
Fix label background in Brand/Light themes

### DIFF
--- a/themes/brand.qss
+++ b/themes/brand.qss
@@ -27,7 +27,7 @@ QGroupBox {
     color: #004B8D;
 }
 QGroupBox::title {
-    background: transparent;
+    background-color: #ffffff;
 }
 
 /* Tool bars use a branded background and buttons */

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -29,7 +29,7 @@ QGroupBox {
     color: #000000;
 }
 QGroupBox::title {
-    background: transparent;
+    background-color: #ffffff;
 }
 
 /* Tool bars use the same light background */


### PR DESCRIPTION
## Summary
- ensure group box titles use white background in light and brand themes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*