### PR TITLE
Add empty rows cleanup step

### DIFF
--- a/src/ui/workflow_wizard.py
+++ b/src/ui/workflow_wizard.py
@@ -13,6 +13,7 @@ class WorkflowWizard(QWizard):
         self.steps = [
             ("Load Excel", self.main_window.open_excel_file),
             ("Clean Sheets", self._clean_sheets),
+            ("Remove Empty Rows", self._remove_empty_rows),
             ("Load SQL", self.main_window.open_sql_file),
             ("Extract SQL Codes", self._extract_sql_codes),
             ("Execute SQL", self.main_window.execute_sql),
@@ -33,6 +34,11 @@ class WorkflowWizard(QWizard):
         viewer = getattr(self.main_window, "excel_viewer", None)
         if viewer and hasattr(viewer, "clean_data"):
             viewer.clean_data()
+
+    def _remove_empty_rows(self):
+        viewer = getattr(self.main_window, "excel_viewer", None)
+        if viewer and hasattr(viewer, "remove_empty_data_rows"):
+            viewer.remove_empty_data_rows()
 
     def _extract_sql_codes(self):
         viewer = getattr(self.main_window, "excel_viewer", None)

--- a/tests/test_workflow_wizard.py
+++ b/tests/test_workflow_wizard.py
@@ -62,13 +62,14 @@ class TestWorkflowWizard(unittest.TestCase):
         window.compare_results = MagicMock(side_effect=lambda: calls.append('compare'))
 
         window.excel_viewer.clean_data = MagicMock(side_effect=lambda: calls.append('clean'))
+        window.excel_viewer.remove_empty_data_rows = MagicMock(side_effect=lambda: calls.append('remove_empty'))
         window.excel_viewer.extract_sql_codes = MagicMock(side_effect=lambda: calls.append('extract'))
         window.excel_viewer.import_column_headers = MagicMock(side_effect=lambda: calls.append('headers'))
 
         wizard = self.WorkflowWizard(window)
         wizard.start()
 
-        self.assertEqual(calls, ['excel', 'clean', 'sql', 'extract', 'execute', 'headers', 'compare'])
+        self.assertEqual(calls, ['excel', 'clean', 'remove_empty', 'sql', 'extract', 'execute', 'headers', 'compare'])
         window.tab_widget.setCurrentIndex.assert_called_with(2)
 
 


### PR DESCRIPTION
## Summary
- add step to remove empty data rows in WorkflowWizard
- test that WorkflowWizard calls remove_empty_data_rows in order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*