### PR TITLE
Handle failure in workflow wizard

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -613,12 +613,19 @@ class MainWindow(QMainWindow):
             )
 
     def execute_sql(self):
-        """Execute the current SQL query"""
+        """Execute the current SQL query
+
+        Returns
+        -------
+        bool
+            ``True`` if the query executed successfully, ``False`` if an error
+            occurred.
+        """
         if not self.db_connector:
             QMessageBox.warning(
                 self, "Not Connected", "Please connect to a database first."
             )
-            return
+            return False
 
         # Get SQL content
         sql_content = self.sql_editor.get_text()
@@ -627,7 +634,7 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(
                 self, "Empty SQL", "Please enter a SQL query to execute."
             )
-            return
+            return False
 
         # Show indeterminate progress dialog
         progress = QProgressDialog("Running SQL query...", None, 0, 0, self)
@@ -722,7 +729,7 @@ class MainWindow(QMainWindow):
                     self, "Query Error", f"Error executing query: {result['error']}"
                 )
                 self.status_bar.showMessage(f"Query failed: {result['error']}")
-                return
+                return False
 
             # Load results into viewer
             if "data" in result:
@@ -743,8 +750,11 @@ class MainWindow(QMainWindow):
                 "Execute Error",
                 f"An error occurred when executing the SQL query: {str(e)}",
             )
+            return False
         finally:
             progress.close()
+
+        return True
 
     def compare_results(self):
         """Compare Excel data with SQL results"""

--- a/src/ui/workflow_wizard.py
+++ b/src/ui/workflow_wizard.py
@@ -1,4 +1,10 @@
-from PyQt6.QtWidgets import QWizard, QWizardPage, QVBoxLayout, QLabel
+from PyQt6.QtWidgets import (
+    QWizard,
+    QWizardPage,
+    QVBoxLayout,
+    QLabel,
+    QMessageBox,
+)
 
 
 class WorkflowWizard(QWizard):
@@ -52,12 +58,19 @@ class WorkflowWizard(QWizard):
 
     def start(self):
         """Execute all steps sequentially."""
-        for _, action in self.steps:
+        for title, action in self.steps:
             try:
-                if callable(action):
-                    action()
-            except Exception:
-                pass
+                result = action() if callable(action) else None
+                if result is False:
+                    QMessageBox.warning(self, "Workflow Failed", f"{title} failed")
+                    self.finished.emit(0)
+                    return
+            except Exception as exc:
+                QMessageBox.critical(
+                    self, "Workflow Error", f"{title} failed: {exc}"
+                )
+                self.finished.emit(0)
+                return
 
         # Show comparison results
         if hasattr(self.main_window, "tab_widget"):

--- a/tests/test_workflow_wizard.py
+++ b/tests/test_workflow_wizard.py
@@ -8,13 +8,24 @@ def patch_qt_modules():
     widgets = types.ModuleType('PyQt6.QtWidgets')
     widget_attrs = [
         "QMainWindow", "QTabWidget", "QApplication", "QWidget", "QVBoxLayout",
-        "QHBoxLayout", "QLabel", "QPushButton", "QFileDialog", "QMessageBox",
-        "QStatusBar", "QMenuBar", "QMenu", "QToolBar", "QSplitter",
-        "QComboBox", "QLineEdit", "QProgressDialog", "QDialog", "QListWidget",
+        "QHBoxLayout", "QLabel", "QPushButton", "QFileDialog", "QStatusBar",
+        "QMenuBar", "QMenu", "QToolBar", "QSplitter", "QComboBox",
+        "QLineEdit", "QProgressDialog", "QDialog", "QListWidget",
         "QDialogButtonBox", "QWizard", "QWizardPage"
     ]
     for attr in widget_attrs:
         setattr(widgets, attr, type(attr, (), {}))
+
+    class QMessageBox:
+        @staticmethod
+        def warning(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def critical(*args, **kwargs):
+            pass
+
+    widgets.QMessageBox = QMessageBox
 
     core = types.ModuleType('PyQt6.QtCore')
     for attr in ["Qt", "QSize"]:
@@ -71,6 +82,34 @@ class TestWorkflowWizard(unittest.TestCase):
 
         self.assertEqual(calls, ['excel', 'clean', 'remove_empty', 'sql', 'extract', 'execute', 'headers', 'compare'])
         window.tab_widget.setCurrentIndex.assert_called_with(2)
+
+    def test_step_failure_stops_execution(self):
+        calls = []
+
+        window = self.MainWindow.__new__(self.MainWindow)
+        window.tab_widget = type('TabWidget', (), {'setCurrentIndex': MagicMock()})()
+        window.excel_viewer = type('Viewer', (), {})()
+
+        window.open_excel_file = MagicMock(side_effect=lambda: calls.append('excel'))
+        window.open_sql_file = MagicMock(side_effect=lambda: calls.append('sql'))
+
+        def fail_execute():
+            calls.append('execute')
+            return False
+
+        window.execute_sql = MagicMock(side_effect=fail_execute)
+        window.compare_results = MagicMock(side_effect=lambda: calls.append('compare'))
+
+        window.excel_viewer.clean_data = MagicMock(side_effect=lambda: calls.append('clean'))
+        window.excel_viewer.remove_empty_data_rows = MagicMock(side_effect=lambda: calls.append('remove_empty'))
+        window.excel_viewer.extract_sql_codes = MagicMock(side_effect=lambda: calls.append('extract'))
+        window.excel_viewer.import_column_headers = MagicMock(side_effect=lambda: calls.append('headers'))
+
+        wizard = self.WorkflowWizard(window)
+        wizard.start()
+
+        self.assertEqual(calls, ['excel', 'clean', 'remove_empty', 'sql', 'extract', 'execute'])
+        window.tab_widget.setCurrentIndex.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- return `True`/`False` from `MainWindow.execute_sql`
- stop wizard on failed step with a `QMessageBox`
- test that failed steps halt the workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*