### PR TITLE
Add Start Testing button and rename workflow actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A high-quality application for testing Excel reports against SQL databases, espe
 - Support for all Excel sheets and formats
 - Intelligent data matching algorithms
 - Configurable report types and parameters
+- Quick **Start Testing** button to launch the automated workflow
 - Choose from Light, Dark, Brand, or System interface themes (Brand is the default)
 
 ## Requirements

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -202,7 +202,7 @@ class MainWindow(QMainWindow):
         compare_action.triggered.connect(self.compare_results)
         tools_menu.addAction(compare_action)
 
-        workflow_action = QAction(qta.icon("fa5s.magic"), "Start Workflow...", self)
+        workflow_action = QAction(qta.icon("fa5s.magic"), "Start Testing", self)
         workflow_action.triggered.connect(self.start_workflow)
         tools_menu.addAction(workflow_action)
 
@@ -260,7 +260,7 @@ class MainWindow(QMainWindow):
         toolbar.addAction(compare_action)
         self._apply_hover_animation(toolbar.widgetForAction(compare_action))
 
-        workflow_action = QAction(qta.icon("fa5s.magic"), "Start Workflow...", self)
+        workflow_action = QAction(qta.icon("fa5s.magic"), "Start Testing", self)
         workflow_action.triggered.connect(self.start_workflow)
         toolbar.addAction(workflow_action)
         self._apply_hover_animation(toolbar.widgetForAction(workflow_action))
@@ -326,6 +326,12 @@ class MainWindow(QMainWindow):
         self.sheet_selector.setMinimumWidth(200)
         self.sheet_selector.currentIndexChanged.connect(self.switch_sheet)
         header_layout.addWidget(self.sheet_selector)
+
+        # Start Testing button
+        self.start_button = QPushButton(qta.icon("fa5s.magic"), "Start Testing")
+        self.start_button.clicked.connect(self.start_workflow)
+        self._apply_hover_animation(self.start_button)
+        header_layout.addWidget(self.start_button)
 
         self.main_layout.addWidget(header_widget)
 


### PR DESCRIPTION
## Summary
- rename workflow actions to **Start Testing**
- add **Start Testing** button to the main window header
- document the button in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and sqlalchemy)*