### PR TITLE
Add configurable report types with dialog

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -914,8 +914,9 @@ class ExcelViewer(QWidget):
             return
         
         try:
-            # Consider only data columns (column index 2+, which is the 3rd column onwards)
-            data_columns = self.df.columns[2:]
+            # Consider only data columns starting at configured index
+            first_col = self.report_config.get("first_data_column", 2)
+            data_columns = self.df.columns[first_col:]
             if len(data_columns) == 0:
                 # No data columns to check
                 return
@@ -1044,8 +1045,9 @@ class ExcelViewer(QWidget):
                     skipped_sheets.append(f"{sheet_name} (not enough columns)")
                     continue
                 
-                # Consider only data columns (column index 2+, which is the 3rd column onwards)
-                data_columns = df.columns[2:]
+                # Consider only data columns starting at configured index
+                first_col = self.report_config.get("first_data_column", 2)
+                data_columns = df.columns[first_col:]
                 
                 # Find rows where all data columns are NULL/NaN or empty string
                 empty_condition = df[data_columns].isna().all(axis=1) | (df[data_columns] == '').all(axis=1)
@@ -1616,8 +1618,9 @@ class ExcelViewer(QWidget):
             clean_df = clean_df.loc[~((clean_df.isna().all(axis=1)) | 
                                 (clean_df.astype(str).apply(lambda x: x.str.strip() == '').all(axis=1)))]
 
-            # Convert all columns to numeric (except Sheet_Name and the label/description column), round, and set back
-            for col in clean_df.columns[2:]:  # skip first two columns
+            # Convert all columns to numeric starting from first_data_column
+            first_col = self.report_config.get("first_data_column", 2)
+            for col in clean_df.columns[first_col:]:
                 clean_df[col] = pd.to_numeric(clean_df[col], errors='coerce').round(2)
 
             # Add a new column with the sheet name at the beginning

--- a/src/ui/report_config_dialog.py
+++ b/src/ui/report_config_dialog.py
@@ -1,0 +1,129 @@
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListWidgetItem,
+    QPushButton, QLineEdit, QLabel, QSpinBox, QDialogButtonBox, QInputDialog
+)
+from PyQt6.QtCore import Qt
+from copy import deepcopy
+from src.utils.config import AppConfig
+
+
+class ReportConfigDialog(QDialog):
+    """Dialog for creating and editing report configurations."""
+
+    def __init__(self, config: AppConfig, parent=None) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.configs = deepcopy(config.get("report_configs") or {})
+        self._original_configs = deepcopy(self.configs)
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        self.setWindowTitle("Report Configurations")
+        layout = QVBoxLayout(self)
+
+        body = QHBoxLayout()
+        self.config_list = QListWidget()
+        self.config_list.addItems(sorted(self.configs.keys()))
+        self.config_list.currentItemChanged.connect(self._on_selected)
+        body.addWidget(self.config_list)
+
+        right = QVBoxLayout()
+        right.addWidget(QLabel("Header rows (comma separated, 1-indexed):"))
+        self.header_edit = QLineEdit()
+        right.addWidget(self.header_edit)
+
+        right.addWidget(QLabel("Rows to skip:"))
+        self.skip_spin = QSpinBox()
+        self.skip_spin.setMinimum(0)
+        right.addWidget(self.skip_spin)
+
+        right.addWidget(QLabel("First data column index:"))
+        self.first_col_spin = QSpinBox()
+        self.first_col_spin.setMinimum(0)
+        self.first_col_spin.setValue(2)
+        right.addWidget(self.first_col_spin)
+
+        right.addWidget(QLabel("Description:"))
+        self.desc_edit = QLineEdit()
+        right.addWidget(self.desc_edit)
+
+        btns = QHBoxLayout()
+        add_btn = QPushButton("Add")
+        add_btn.clicked.connect(self._add_config)
+        del_btn = QPushButton("Delete")
+        del_btn.clicked.connect(self._delete_config)
+        btns.addWidget(add_btn)
+        btns.addWidget(del_btn)
+        right.addLayout(btns)
+
+        body.addLayout(right)
+        layout.addLayout(body)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self.save)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        if self.config_list.count() > 0:
+            self.config_list.setCurrentRow(0)
+        else:
+            self._clear_fields()
+
+    def _clear_fields(self) -> None:
+        self.header_edit.clear()
+        self.skip_spin.setValue(0)
+        self.first_col_spin.setValue(2)
+        self.desc_edit.clear()
+
+    def _on_selected(self, current: QListWidgetItem, previous: QListWidgetItem) -> None:
+        if previous:
+            self._save_config(previous.text())
+        if current:
+            cfg = self.configs.get(current.text(), {})
+            self.header_edit.setText(
+                ", ".join(str(i + 1) for i in cfg.get("header_rows", []))
+            )
+            self.skip_spin.setValue(cfg.get("skip_rows", 0))
+            self.first_col_spin.setValue(cfg.get("first_data_column", 2))
+            self.desc_edit.setText(cfg.get("description", ""))
+        else:
+            self._clear_fields()
+
+    def _save_config(self, name: str) -> None:
+        rows = [int(v.strip()) - 1 for v in self.header_edit.text().split(',') if v.strip()]
+        self.configs[name] = {
+            "header_rows": rows,
+            "skip_rows": self.skip_spin.value(),
+            "first_data_column": self.first_col_spin.value(),
+            "description": self.desc_edit.text(),
+        }
+
+    def _add_config(self) -> None:
+        name, ok = QInputDialog.getText(self, "Add Report Type", "Name:")
+        if ok and name and name not in self.configs:
+            self.configs[name] = {
+                "header_rows": [],
+                "skip_rows": 0,
+                "first_data_column": 2,
+                "description": "",
+            }
+            self.config_list.addItem(name)
+            self.config_list.setCurrentRow(self.config_list.count() - 1)
+
+    def _delete_config(self) -> None:
+        item = self.config_list.currentItem()
+        if not item:
+            return
+        name = item.text()
+        if name in self.configs:
+            del self.configs[name]
+        row = self.config_list.row(item)
+        self.config_list.takeItem(row)
+        self._clear_fields()
+
+    def save(self) -> None:
+        if self.config_list.currentItem():
+            self._save_config(self.config_list.currentItem().text())
+        self.config.config["report_configs"] = self.configs
+        self.config.save_config()
+        self.accept()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -72,7 +72,8 @@ class AppConfig:
                 "comparison_threshold": 1.0  # 1% difference allowed
             },
             "account_categories": {},
-            "account_formulas": {}
+            "account_formulas": {},
+            "report_configs": self.initialize_report_configs()
         }
         
         # Create config file if it doesn't exist
@@ -99,6 +100,13 @@ class AppConfig:
                         if key not in config[section]:
                             config[section][key] = default_config[section][key]
                             updated = True
+
+            # Merge report_configs separately to preserve user additions
+            merged_reports = default_config["report_configs"].copy()
+            merged_reports.update(config.get("report_configs", {}))
+            if config.get("report_configs") != merged_reports:
+                updated = True
+            config["report_configs"] = merged_reports
             
             if updated:
                 self.save_config(config)
@@ -228,4 +236,61 @@ class AppConfig:
             self.config["account_formulas"] = {}
 
         self.config["account_formulas"][report_type] = formulas
+        self.save_config()
+
+    # Report configuration helpers -------------------------------------------------
+
+    def initialize_report_configs(self):
+        """Return default report configurations."""
+        return {
+            "SOO PreClose": {
+                "header_rows": [5, 6],
+                "skip_rows": 7,
+                "first_data_column": 2,
+                "description": "SOO PreClose report with headers on rows 6 and 7",
+            },
+            "SOO MFR": {
+                "header_rows": [3, 4],
+                "skip_rows": 5,
+                "first_data_column": 2,
+                "description": "SOO MFR report with headers on rows 4 and 5",
+            },
+            "Executive Book": {
+                "header_rows": [2, 3],
+                "skip_rows": 4,
+                "first_data_column": 2,
+                "description": "Executive Book report with headers on rows 3 and 4",
+            },
+            "Statement of Operations": {
+                "header_rows": [4, 5],
+                "skip_rows": 6,
+                "first_data_column": 2,
+                "description": "Statement of Operations report with headers on rows 5 and 6",
+            },
+            "Corp SOO": {
+                "header_rows": [5, 6],
+                "skip_rows": 7,
+                "first_data_column": 2,
+                "description": "Corporate SOO report with headers on rows 6 and 7",
+            },
+            "AR Center": {
+                "header_rows": [4, 5],
+                "skip_rows": 6,
+                "first_data_column": 2,
+                "description": "AR Center report with headers on rows 5 and 6",
+            },
+        }
+
+    def get_report_config(self, name):
+        """Retrieve report configuration by name."""
+        cfg = self.config.get("report_configs", {}).get(name)
+        if cfg and "first_data_column" not in cfg:
+            cfg["first_data_column"] = 2
+        return cfg
+
+    def set_report_config(self, name, cfg):
+        """Set a report configuration and persist it."""
+        if "report_configs" not in self.config:
+            self.config["report_configs"] = {}
+        self.config["report_configs"][name] = cfg
         self.save_config()

--- a/tests/test_gather_accounts.py
+++ b/tests/test_gather_accounts.py
@@ -43,7 +43,8 @@ def patch_qt_modules():
     for name in [
         'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
         'src.ui.comparison_view', 'src.ui.settings_dialog',
-        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+        'src.ui.account_category_dialog', 'src.ui.report_config_dialog',
+        'src.ui.hover_anim_filter'
     ]:
         sys.modules.setdefault(name, types.ModuleType(name))
 

--- a/tests/test_gather_accounts_nodash.py
+++ b/tests/test_gather_accounts_nodash.py
@@ -43,7 +43,8 @@ def patch_qt_modules():
     for name in [
         'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
         'src.ui.comparison_view', 'src.ui.settings_dialog',
-        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+        'src.ui.account_category_dialog', 'src.ui.report_config_dialog',
+        'src.ui.hover_anim_filter'
     ]:
         sys.modules.setdefault(name, types.ModuleType(name))
 

--- a/tests/test_gather_accounts_numeric.py
+++ b/tests/test_gather_accounts_numeric.py
@@ -43,7 +43,8 @@ def patch_qt_modules():
     for name in [
         'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
         'src.ui.comparison_view', 'src.ui.settings_dialog',
-        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+        'src.ui.account_category_dialog', 'src.ui.report_config_dialog',
+        'src.ui.hover_anim_filter'
     ]:
         sys.modules.setdefault(name, types.ModuleType(name))
 

--- a/tests/test_gather_accounts_sheetname.py
+++ b/tests/test_gather_accounts_sheetname.py
@@ -41,7 +41,8 @@ def patch_qt_modules():
     for name in [
         'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
         'src.ui.comparison_view', 'src.ui.settings_dialog',
-        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+        'src.ui.account_category_dialog', 'src.ui.report_config_dialog',
+        'src.ui.hover_anim_filter'
     ]:
         sys.modules.setdefault(name, types.ModuleType(name))
 

--- a/tests/test_report_configs.py
+++ b/tests/test_report_configs.py
@@ -1,0 +1,92 @@
+import os
+import sys
+import types
+import tempfile
+import unittest
+
+
+def patch_qt_modules():
+    """Provide minimal PyQt stubs so ExcelViewer can be imported."""
+    widgets = types.ModuleType('PyQt6.QtWidgets')
+    widget_attrs = [
+        'QWidget', 'QVBoxLayout', 'QHBoxLayout', 'QTableView', 'QLabel',
+        'QPushButton', 'QComboBox', 'QLineEdit', 'QHeaderView', 'QSplitter',
+        'QCheckBox', 'QGroupBox', 'QFormLayout', 'QSpinBox', 'QTabWidget',
+        'QStyledItemDelegate', 'QInputDialog', 'QListWidget', 'QDialog',
+        'QTextEdit', 'QDialogButtonBox', 'QRadioButton', 'QButtonGroup',
+        'QListWidgetItem'
+    ]
+    for attr in widget_attrs:
+        setattr(widgets, attr, type(attr, (), {}))
+
+    core = types.ModuleType('PyQt6.QtCore')
+    for attr in [
+        'Qt', 'QAbstractTableModel', 'QModelIndex', 'QVariant',
+        'pyqtSignal', 'QEvent', 'QSize'
+    ]:
+        setattr(core, attr, type(attr, (), {}))
+
+    gui = types.ModuleType('PyQt6.QtGui')
+    for attr in ['QFont', 'QColor', 'QBrush', 'QIcon', 'QGuiApplication', 'QCursor']:
+        setattr(gui, attr, type(attr, (), {}))
+
+    sys.modules.setdefault('PyQt6', types.ModuleType('PyQt6'))
+    sys.modules['PyQt6.QtWidgets'] = widgets
+    sys.modules['PyQt6.QtCore'] = core
+    sys.modules['PyQt6.QtGui'] = gui
+
+    qta = types.ModuleType('qtawesome')
+    qta.icon = lambda *args, **kwargs: None
+    sys.modules['qtawesome'] = qta
+
+
+class ReportConfigTests(unittest.TestCase):
+    def setUp(self):
+        patch_qt_modules()
+
+    def test_config_save_and_load(self):
+        from src.utils.config import AppConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            old_home = os.environ.get('HOME')
+            os.environ['HOME'] = tmp
+
+            cfg = AppConfig()
+            rc = cfg.get_report_config('SOO PreClose')
+            rc['skip_rows'] = 99
+            cfg.set_report_config('SOO PreClose', rc)
+
+            cfg2 = AppConfig()
+            self.assertEqual(cfg2.get_report_config('SOO PreClose')['skip_rows'], 99)
+
+            if old_home is not None:
+                os.environ['HOME'] = old_home
+            else:
+                del os.environ['HOME']
+
+    def test_clean_dataframe_uses_first_column(self):
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 1,
+            'description': ''
+        }
+
+        import pandas as pd
+        df = pd.DataFrame([
+            ['H1', 'H2', 'H3'],
+            ['skip1', 'skip2', 'skip3'],
+            ['desc', '1', '2'],
+            ['desc2', '3', '4']
+        ])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertEqual(cleaned.iloc[0, 1], 1)
+        self.assertEqual(cleaned.iloc[1, 1], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_workflow_wizard.py
+++ b/tests/test_workflow_wizard.py
@@ -47,7 +47,8 @@ def patch_qt_modules():
     for name in [
         'src.ui.excel_viewer', 'src.ui.sql_editor', 'src.ui.results_viewer',
         'src.ui.comparison_view', 'src.ui.settings_dialog',
-        'src.ui.account_category_dialog', 'src.ui.hover_anim_filter'
+        'src.ui.account_category_dialog', 'src.ui.report_config_dialog',
+        'src.ui.hover_anim_filter'
     ]:
         sys.modules.setdefault(name, types.ModuleType(name))
 


### PR DESCRIPTION
## Summary
- add report_configs to AppConfig and helper methods
- load report types from config in MainWindow and provide Manage Report Types dialog
- reference first_data_column when cleaning excel data
- create ReportConfigDialog for editing report configurations
- patch tests to stub new dialog and add new tests for configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and sqlalchemy)*