### PR TITLE
Support account numbers in formulas

### DIFF
--- a/src/ui/account_category_dialog.py
+++ b/src/ui/account_category_dialog.py
@@ -150,7 +150,7 @@ class AccountCategoryDialog(QDialog):
         self.category_drag_list.setDragEnabled(True)
         right.addWidget(self.category_drag_list)
 
-        right.addWidget(QLabel("Formula expression (use category names):"))
+        right.addWidget(QLabel("Formula expression (use category names or account numbers):"))
         self.formula_edit = FormulaLineEdit()
         self.formula_edit.textChanged.connect(self._formula_changed)
         right.addWidget(self.formula_edit)

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -233,6 +233,20 @@ class TestCategoryCalculator(unittest.TestCase):
         )
         self.assertEqual(net_c2["Amount"], 7)
 
+    def test_formula_with_account_reference(self):
+        rows = [
+            {"CAReportName": "1234-5678", "Amount": -100},
+            {"CAReportName": "5555-5555", "Amount": 20},
+        ]
+        categories = {"CatA": ["1234-5678"]}
+        formulas = {"NetAcct": "CatA + 5555-5555"}
+        calc = CategoryCalculator(categories, formulas)
+        result = calc.compute(list(rows))
+
+        net = next(r for r in result if r["CAReportName"] == "NetAcct")
+        self.assertEqual(net["Amount"], -80)
+        self.assertFalse(any(r["CAReportName"] == "5555-5555" for r in result))
+
     def test_all_decimal_amounts_grouped(self):
         rows = [
             {"Center": 1, "CAReportName": "1234-5678", "Amount": Decimal("1")},


### PR DESCRIPTION
## Summary
- allow formulas to reference single accounts in `CategoryCalculator`
- label formula field to mention account numbers
- test new account reference logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*