### PR TITLE
Add PyInstaller spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wheels/
 # PyInstaller
 *.manifest
 *.spec
+!soo_preclose.spec
 
 # Installer logs
 pip-log.txt

--- a/soo_preclose.spec
+++ b/soo_preclose.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=[os.path.abspath(".")],
+    binaries=[],
+    datas=[('themes/*.qss', 'themes')],
+    hiddenimports=['src.plugins'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='SOO_PreClose_Tester',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    name='SOO_PreClose_Tester',
+)


### PR DESCRIPTION
## Summary
- create `soo_preclose.spec` with data files and plugins
- allow the spec to be tracked by Git via `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*