### PR TITLE
Update report type handling in Excel viewer

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -169,6 +169,9 @@ class ExcelViewer(QWidget):
             "skip_rows": 7,         # Skip rows 0-6 (header is at 5-6)
             "description": "SOO PreClose report with headers on rows 6 and 7"
         }
+        # Current report type associated with the configuration
+        self.report_type = None
+
         
         self.init_ui()
         
@@ -519,9 +522,10 @@ class ExcelViewer(QWidget):
             
         return False
         
-    def set_report_config(self, config):
-        """Set the report configuration to use for sheet cleaning"""
+    def set_report_config(self, config, report_type=None):
+        """Set the report configuration and associated report type."""
         self.report_config = config
+        self.report_type = report_type
         
         # Update the clean button tooltip to reflect the new configuration
         if hasattr(self, 'clean_button'):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1555,9 +1555,9 @@ class MainWindow(QMainWindow):
         # Update local copy
         self.report_configs[report_type] = report_config
 
-        # Update Excel viewer with the report configuration
+        # Update Excel viewer with the report configuration and type
         if hasattr(self, "excel_viewer"):
-            self.excel_viewer.set_report_config(report_config)
+            self.excel_viewer.set_report_config(report_config, report_type)
 
         # If we have an Excel analyzer, update its configuration as well
         if self.excel_analyzer:


### PR DESCRIPTION
## Summary
- store `report_type` on `ExcelViewer`
- propagate report type through `set_report_config`
- update `MainWindow` to send the report type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*