### PR TITLE
Add MFR PreClose config and cleaning

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1657,7 +1657,10 @@ class ExcelViewer(QWidget):
         if clean_df is None:
             return None
 
-        if self.report_type == "SOO MFR":
+        # Remove original row indices left from the source file
+        clean_df = clean_df.reset_index(drop=True)
+
+        if self.report_type in ("SOO MFR", "MFR PreClose"):
             from PyQt6.QtWidgets import QInputDialog
 
             if not hasattr(self, "_mfr_month_year"):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -255,6 +255,12 @@ class AppConfig:
                 "first_data_column": 4,
                 "description": "SOO MFR report with header on row 10",
             },
+            "MFR PreClose": {
+                "header_rows": [9],
+                "skip_rows": 10,
+                "first_data_column": 4,
+                "description": "MFR PreClose report with header on row 10",
+            },
             "Executive Book": {
                 "header_rows": [2, 3],
                 "skip_rows": 4,

--- a/tests/test_mfr_cleaning.py
+++ b/tests/test_mfr_cleaning.py
@@ -38,6 +38,37 @@ class TestMFRCleaning(unittest.TestCase):
         ]
         self.assertEqual(list(cleaned.columns), expected)
 
+    def test_mfr_preclose_headers_prefixed(self):
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 4,
+            'description': ''
+        }
+        viewer.report_type = 'MFR PreClose'
+
+        df = pd.DataFrame([
+            ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S'],
+            [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+        ])
+
+        from PyQt6.QtWidgets import QInputDialog
+        responses = iter([('May', True), ('2025', True)])
+        QInputDialog.getItem = staticmethod(lambda *a, **k: next(responses))
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertIsNotNone(cleaned)
+        expected = [
+            'Sheet_Name','A','B','C',
+            'May 2025 D','May 2025 E','May 2025 F','May 2025 G','May 2025 H','May 2025 I',
+            'May 2024 J','May 2024 K','May 2024 L',
+            'YTD May 2025 M','YTD May 2025 N','YTD May 2025 O','YTD May 2025 P',
+            'YTD May 2024 Q','YTD May 2024 R','YTD May 2024 S'
+        ]
+        self.assertEqual(list(cleaned.columns), expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_report_configs.py
+++ b/tests/test_report_configs.py
@@ -78,6 +78,29 @@ class ReportConfigTests(unittest.TestCase):
             else:
                 del os.environ['HOME']
 
+    def test_mfr_preclose_default_config(self):
+        from src.utils.config import AppConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            old_home = os.environ.get('HOME')
+            os.environ['HOME'] = tmp
+
+            cfg = AppConfig()
+            self.assertEqual(
+                cfg.get_report_config('MFR PreClose'),
+                {
+                    'header_rows': [9],
+                    'skip_rows': 10,
+                    'first_data_column': 4,
+                    'description': 'MFR PreClose report with header on row 10'
+                }
+            )
+
+            if old_home is not None:
+                os.environ['HOME'] = old_home
+            else:
+                del os.environ['HOME']
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add default config for MFR PreClose reports
- treat `MFR PreClose` like `SOO MFR` for column prefixing
- reset index after base cleaning
- test default config and MFR PreClose cleaning behaviour

## Testing
- `pytest tests/test_report_configs.py -q`
