### PR TITLE
Fix prefix logic for MFR cleaning

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1681,11 +1681,19 @@ class ExcelViewer(QWidget):
             else:
                 mon, yr = self._mfr_month_year
 
+            # Determine where the actual numeric data starts.  The base
+            # cleaning routine inserts a ``Sheet_Name`` column at position 0,
+            # so offset the configured ``first_data_column`` by one.
+            data_start = self.report_config.get("first_data_column", 2) + 1
+
+            # Build the prefix ranges relative to ``data_start`` so that the
+            # correct columns are renamed even when ``first_data_column`` is
+            # customised by different report configurations.
             prefixes = (
-                (range(4, 10), f"{mon} {yr} "),
-                (range(10, 13), f"{mon} {yr - 1} "),
-                (range(13, 17), f"YTD {mon} {yr} "),
-                (range(17, 20), f"YTD {mon} {yr - 1} "),
+                (range(data_start, data_start + 6), f"{mon} {yr} "),
+                (range(data_start + 6, data_start + 9), f"{mon} {yr - 1} "),
+                (range(data_start + 9, data_start + 13), f"YTD {mon} {yr} "),
+                (range(data_start + 13, data_start + 16), f"YTD {mon} {yr - 1} "),
             )
 
             for cols, prefix in prefixes:

--- a/tests/test_mfr_cleaning.py
+++ b/tests/test_mfr_cleaning.py
@@ -69,6 +69,36 @@ class TestMFRCleaning(unittest.TestCase):
         ]
         self.assertEqual(list(cleaned.columns), expected)
 
+    def test_prefix_respects_first_data_column(self):
+        """Columns starting at index defined by ``first_data_column`` should be
+        prefixed after cleaning."""
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 2,
+            'description': ''
+        }
+        viewer.report_type = 'SOO MFR'
+
+        df = pd.DataFrame([
+            ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S'],
+            [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+        ])
+
+        from PyQt6.QtWidgets import QInputDialog
+        responses = iter([('May', True), ('2025', True)])
+        QInputDialog.getItem = staticmethod(lambda *a, **k: next(responses))
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertIsNotNone(cleaned)
+
+        # Columns C and D correspond to indices 2 and 3. With ``first_data_column``
+        # set to 2, these should receive prefixes.
+        self.assertEqual(cleaned.columns[3], 'May 2025 D')
+        self.assertEqual(cleaned.columns[4], 'May 2025 E')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `_clean_dataframe` prefix ranges
- ensure prefix logic respects configured `first_data_column`
- add regression test for prefixing when `first_data_column` is 2

## Testing
- `pytest tests/test_mfr_cleaning.py::TestMFRCleaning::test_prefix_respects_first_data_column -q` *(fails: ModuleNotFoundError: No module named 'pandas')*