### PR TITLE
Fix duplicate header row cleanup

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1685,6 +1685,21 @@ class ExcelViewer(QWidget):
         # Remove original row indices left from the source file
         clean_df = clean_df.reset_index(drop=True)
 
+        # If the first row appears to repeat the column headers (which can occur
+        # when export utilities duplicate the header row), drop it so that the
+        # actual data starts immediately after the configured ``skip_rows``
+        if not clean_df.empty:
+            header_vals = [str(c).strip().lower() for c in clean_df.columns]
+            row_vals = [str(v).strip().lower() for v in clean_df.iloc[0].tolist()]
+
+            # Ignore the sheet name column when comparing
+            if header_vals and header_vals[0] == "sheet_name":
+                header_vals = header_vals[1:]
+                row_vals = row_vals[1:]
+
+            if row_vals == header_vals:
+                clean_df = clean_df.iloc[1:].reset_index(drop=True)
+
         if self.report_type in ("SOO MFR", "MFR PreClose"):
             from PyQt6.QtWidgets import QInputDialog
 

--- a/tests/test_remove_duplicate_header_row.py
+++ b/tests/test_remove_duplicate_header_row.py
@@ -1,0 +1,39 @@
+import unittest
+import pandas as pd
+from tests.qt_stubs import patch_qt_modules
+
+
+class TestRemoveDuplicateHeaderRow(unittest.TestCase):
+    def setUp(self):
+        patch_qt_modules()
+
+    def test_duplicate_header_row_removed(self):
+        from src.ui.excel_viewer import ExcelViewer
+
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 1,
+            'description': ''
+        }
+
+        # Row 0 is the header, row 1 repeats the header which should be removed
+        df = pd.DataFrame([
+            ['A', 'B', 'C'],
+            ['A', 'B', 'C'],
+            ['desc', '1', '2'],
+        ])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertIsNotNone(cleaned)
+        # After removing the duplicate header row we should only have one data row
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(list(cleaned.columns), ['Sheet_Name', 'A', 'B', 'C'])
+        self.assertEqual(cleaned.iloc[0, 1], 'desc')
+        self.assertEqual(cleaned.iloc[0, 2], 1.0)
+        self.assertEqual(cleaned.iloc[0, 3], 2.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- drop duplicate header row if it appears in cleaned sheets
- test cleaning when first data row duplicates headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*