### PR TITLE
Adjust sheet name handling for SOO MFR

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1082,7 +1082,10 @@ class ExcelViewer(QWidget):
                 ).round(2)
 
             # Add a new column with the sheet name at the beginning
-            clean_df.insert(0, "Sheet_Name", sheet_name)
+            # Skip this for SOO MFR where including the sheet name would
+            # interfere with comparisons.
+            if self.report_type != "SOO MFR":
+                clean_df.insert(0, "Sheet_Name", sheet_name)
 
             return clean_df
 
@@ -1771,10 +1774,13 @@ class ExcelViewer(QWidget):
             else:
                 mon, yr = self._mfr_month_year
 
-            # Determine where the actual numeric data starts.  The base
-            # cleaning routine inserts a ``Sheet_Name`` column at position 0,
-            # so offset the configured ``first_data_column`` by one.
-            data_start = self.report_config.get("first_data_column", 2) + 1
+            # Determine where the actual numeric data starts. The base cleaning
+            # routine normally inserts a ``Sheet_Name`` column at position 0.
+            # For SOO MFR that column is omitted, so only offset when it is
+            # present.
+            data_start = self.report_config.get("first_data_column", 2)
+            if self.report_type != "SOO MFR":
+                data_start += 1
 
             # Build the prefix ranges relative to ``data_start`` so that the
             # correct columns are renamed even when ``first_data_column`` is

--- a/tests/test_mfr_cleaning.py
+++ b/tests/test_mfr_cleaning.py
@@ -30,7 +30,7 @@ class TestMFRCleaning(unittest.TestCase):
         cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
         self.assertIsNotNone(cleaned)
         expected = [
-            'Sheet_Name','A','B','C',
+            'A','B','C',
             'May 2025 D','May 2025 E','May 2025 F','May 2025 G','May 2025 H','May 2025 I',
             'May 2024 J','May 2024 K','May 2024 L',
             'YTD May 2025 M','YTD May 2025 N','YTD May 2025 O','YTD May 2025 P',
@@ -96,6 +96,7 @@ class TestMFRCleaning(unittest.TestCase):
 
         # Columns C and D correspond to indices 2 and 3. With ``first_data_column``
         # set to 2, these should receive prefixes.
+        self.assertEqual(cleaned.columns[2], 'May 2025 C')
         self.assertEqual(cleaned.columns[3], 'May 2025 D')
         self.assertEqual(cleaned.columns[4], 'May 2025 E')
 


### PR DESCRIPTION
## Summary
- skip inserting `Sheet_Name` column for SOO MFR reports
- offset MFR prefix logic only when sheet name column exists
- update SOO MFR tests to expect no Sheet_Name column

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*