### PR TITLE
Add CAReportName extraction for MFR

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1381,15 +1381,27 @@ class ExcelViewer(QWidget):
             account_patterns = ACCOUNT_PATTERNS
             account_codes = set()
             missing_column_sheets = []
+
+            is_name_column = selected_column.strip().lower() in (
+                "careportname",
+                "ca report name",
+                "ca reportname",
+            )
             
             # First get account codes from the current sheet
             if self.df is not None and selected_column in self.df.columns:
                 column_data = self.df[selected_column].astype(str)
-                for value in column_data:
-                    for pattern in account_patterns:
-                        matches = re.findall(pattern, value)
-                        for match in matches:
-                            account_codes.add(match)
+                if is_name_column:
+                    for value in column_data:
+                        val = value.strip()
+                        if val:
+                            account_codes.add(val)
+                else:
+                    for value in column_data:
+                        for pattern in account_patterns:
+                            matches = re.findall(pattern, value)
+                            for match in matches:
+                                account_codes.add(match)
             else:
                 missing_column_sheets.append(self.sheet_name)
             
@@ -1413,11 +1425,17 @@ class ExcelViewer(QWidget):
                         # Check if the selected column exists in this sheet
                         if selected_column in sheet_df.columns:
                             column_data = sheet_df[selected_column].astype(str)
-                            for value in column_data:
-                                for pattern in account_patterns:
-                                    matches = re.findall(pattern, value)
-                                    for match in matches:
-                                        account_codes.add(match)
+                            if is_name_column:
+                                for value in column_data:
+                                    val = value.strip()
+                                    if val:
+                                        account_codes.add(val)
+                            else:
+                                for value in column_data:
+                                    for pattern in account_patterns:
+                                        matches = re.findall(pattern, value)
+                                        for match in matches:
+                                            account_codes.add(match)
                         else:
                             missing_column_sheets.append(sheet_name)
                     except Exception as e:

--- a/tests/test_extract_sql_codes.py
+++ b/tests/test_extract_sql_codes.py
@@ -1,0 +1,38 @@
+import os
+import pandas as pd
+import unittest
+from unittest.mock import MagicMock
+
+from tests.qt_stubs import patch_qt_modules
+
+class TestExtractSQLCodes(unittest.TestCase):
+    def setUp(self):
+        patch_qt_modules()
+        from src.ui.excel_viewer import ExcelViewer
+        self.ExcelViewer = ExcelViewer
+
+    def test_extract_careportname(self):
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.df = pd.DataFrame({
+            'CAReportName': ['Acct A', 'Acct B'],
+            'Value': [1, 2]
+        })
+        viewer.sheet_name = '2001-001'
+        viewer.report_type = 'SOO MFR'
+        viewer.select_sheets_dialog = lambda sheets: [viewer.sheet_name]
+        captured = {}
+        viewer.show_extracted_sql = lambda cs, asql, centers, accounts, *a, **k: captured.update({
+            'center_sql': cs, 'account_sql': asql, 'centers': centers, 'accounts': accounts
+        })
+        from PyQt6.QtWidgets import QInputDialog
+        QInputDialog.getItem = staticmethod(lambda *a, **k: ('CAReportName', True))
+
+        viewer.extract_sql_codes()
+
+        self.assertEqual(captured['accounts'], {'Acct A', 'Acct B'})
+        self.assertIn("'Acct A'", captured['account_sql'])
+        self.assertIn('2001-001', captured['centers'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support using CAReportName text when extracting SQL codes
- test extracting CAReportName values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840bceb6aac833299531de4beea49c6