### PR TITLE
Update extract_sql_codes logic for name column

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1387,6 +1387,10 @@ class ExcelViewer(QWidget):
                 "ca report name",
                 "ca reportname",
             )
+            if not is_name_column and self.report_type in ("SOO MFR", "MFR PreClose"):
+                if self.df.columns.get_loc(selected_column) == 0:
+                    # CAReportName becomes column A after cleaning
+                    is_name_column = True
             
             # First get account codes from the current sheet
             if self.df is not None and selected_column in self.df.columns:

--- a/tests/test_extract_sql_codes.py
+++ b/tests/test_extract_sql_codes.py
@@ -34,5 +34,28 @@ class TestExtractSQLCodes(unittest.TestCase):
         self.assertIn("'Acct A'", captured['account_sql'])
         self.assertIn('2001-001', captured['centers'])
 
+    def test_extract_first_column_mfr(self):
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.df = pd.DataFrame({
+            'A': ['Acct A', 'Acct B'],
+            'B': [1, 2]
+        })
+        viewer.sheet_name = '2001-001'
+        viewer.report_type = 'SOO MFR'
+        viewer.select_sheets_dialog = lambda sheets: [viewer.sheet_name]
+        captured = {}
+        viewer.show_extracted_sql = lambda cs, asql, centers, accounts, *a, **k: captured.update({
+            'center_sql': cs, 'account_sql': asql, 'centers': centers, 'accounts': accounts
+        })
+        from PyQt6.QtWidgets import QInputDialog
+        QInputDialog.getItem = staticmethod(lambda *a, **k: ('A', True))
+
+        viewer.extract_sql_codes()
+
+        self.assertEqual(captured['accounts'], {'Acct A', 'Acct B'})
+        self.assertIn("'Acct A'", captured['account_sql'])
+        self.assertIn('2001-001', captured['centers'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- detect CAReportName column when it appears as column A on SOO MFR/MFR PreClose reports
- add regression test for first-column CAReportName detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840c0e717508332a62fcd1cbd307064