### PR TITLE
Normalize join key whitespace/case in comparisons

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -117,9 +117,19 @@ class ComparisonEngine:
             
         self.logger.info(f"Using key columns for joining: {key_columns}")
         
-        # Create join keys
-        excel_keys = excel_df[key_columns['excel']].astype(str).agg('-'.join, axis=1)
-        sql_keys = sql_df[key_columns['sql']].astype(str).agg('-'.join, axis=1)
+        # Create join keys with normalized case/whitespace
+        excel_keys = (
+            excel_df[key_columns['excel']]
+            .astype(str)
+            .apply(lambda s: s.str.strip().str.lower())
+            .agg('-'.join, axis=1)
+        )
+        sql_keys = (
+            sql_df[key_columns['sql']]
+            .astype(str)
+            .apply(lambda s: s.str.strip().str.lower())
+            .agg('-'.join, axis=1)
+        )
         
         # --- Duplicate key detection ---
         excel_dup_keys = excel_keys[excel_keys.duplicated(keep=False)]
@@ -486,9 +496,19 @@ class ComparisonEngine:
         # Prepare sign flip accounts as a set of stripped strings
         sign_flip_accounts_str = set(str(acct).strip() for acct in getattr(self, 'sign_flip_accounts', set()))
         
-        # Create join keys
-        excel_keys = excel_df[key_columns['excel']].astype(str).agg('-'.join, axis=1)
-        sql_keys = sql_df[key_columns['sql']].astype(str).agg('-'.join, axis=1)
+        # Create join keys with normalized case/whitespace
+        excel_keys = (
+            excel_df[key_columns['excel']]
+            .astype(str)
+            .apply(lambda s: s.str.strip().str.lower())
+            .agg('-'.join, axis=1)
+        )
+        sql_keys = (
+            sql_df[key_columns['sql']]
+            .astype(str)
+            .apply(lambda s: s.str.strip().str.lower())
+            .agg('-'.join, axis=1)
+        )
         
         excel_df = excel_df.copy()
         sql_df = sql_df.copy()

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -51,3 +51,20 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         results = self.engine.compare_dataframes(self.excel_df, self.sql_df)
         self.assertIn('discrepancy_severity', results)
         self.assertIn('major', results['discrepancy_severity'])
+
+    def test_key_whitespace_and_case_normalization(self):
+        excel_df = pd.DataFrame({
+            'Center': [1],
+            'CAReportName': ['Acct A '],
+            'Amount': [100]
+        })
+        sql_df = pd.DataFrame({
+            'Center': [1],
+            'CAReportName': ['acct a'],
+            'Amount': [100]
+        })
+        engine = ComparisonEngine()
+        results = engine.compare_dataframes(excel_df, sql_df)
+        self.assertEqual(results['row_counts']['matched'], 1)
+        detailed = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
+        self.assertTrue((detailed['Result'] == 'Match').all())


### PR DESCRIPTION
## Summary
- normalize key columns when creating join keys
- handle the same logic in the detailed comparison dataframe
- test whitespace and case normalization for keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840c3b8d96c8332a35d11f6d16eec04