### PR TITLE
Fix Corp SOO numeric zero detection

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1031,7 +1031,9 @@ class ExcelViewer(QWidget):
                 col_data = data_df.iloc[:, i]
                 is_empty = col_data.isna().all() or (col_data.astype(str).str.strip() == '').all()
                 if self.report_type == "Corp SOO":
-                    is_empty = is_empty or (pd.to_numeric(col_data, errors="coerce").fillna(0) == 0).all()
+                    numeric_series = pd.to_numeric(col_data, errors="coerce")
+                    if numeric_series.notna().any():
+                        is_empty = is_empty or numeric_series.fillna(0).eq(0).all()
                 if is_empty:
                     empty_cols.append(i)
 

--- a/tests/test_corp_soo_cleaning.py
+++ b/tests/test_corp_soo_cleaning.py
@@ -31,5 +31,29 @@ class TestCorpSOOCleaning(unittest.TestCase):
         self.assertEqual(len(cleaned), 1)
         self.assertEqual(cleaned.iloc[0].tolist(), ['acct2', 1.0, 2.0])
 
+    def test_text_column_not_dropped(self):
+        """Purely textual columns should be preserved when cleaning."""
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 2,
+            'description': ''
+        }
+        viewer.report_type = 'Corp SOO'
+
+        df = pd.DataFrame([
+            ['CAReportName', 'Val1', 'Val2'],
+            ['TextA', 0, 0],
+            ['TextB', 1, 2]
+        ])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(list(cleaned.columns), ['CAReportName', 'Val1', 'Val2'])
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(cleaned.iloc[0].tolist(), ['TextB', 1.0, 2.0])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid dropping text columns when cleaning Corp SOO reports
- add regression test ensuring textual columns are preserved

## Testing
- `pytest -q tests/test_corp_soo_cleaning.py::TestCorpSOOCleaning::test_text_column_not_dropped -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a98657908332b7d3120f42b975c9