### PR TITLE
Add test dependency setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ Use `pytest` to run the unit tests:
 ```
 pytest
 ```
+Before running the tests in a fresh environment make sure the required
+dependencies are installed. A helper script is provided which installs the
+packages listed in `requirements.txt` as well as the lightweight PyQt stubs used
+by the tests:
+
+```bash
+./scripts/install_test_deps.sh
+```
+
+After installing the dependencies the test suite can be executed with
+`pytest -q`.
 
 ## Building the Executable
 

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install dependencies required for running the test suite.
+# Run from the repository root.
+set -e
+
+# Upgrade pip to reduce possible install issues.
+pip install --upgrade pip
+
+# Install project and runtime dependencies
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+# Install the package itself in editable mode
+if [ -f pyproject.toml ]; then
+    pip install -e .
+fi
+
+# PyQt6-stubs provides type information for PyQt and is small enough for CI
+pip install PyQt6-stubs


### PR DESCRIPTION
## Summary
- add `scripts/install_test_deps.sh` helper
- document how to use the helper in README

## Testing
- `bash scripts/install_test_deps.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848abc2df088332b1e68f3345297f99