### PR TITLE
Handle merged headers during cleaning

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1014,7 +1014,15 @@ class ExcelViewer(QWidget):
             # Get header rows from the configuration
             header_rows = []
             for idx in header_row_indices:
-                header_rows.append(df.iloc[idx])
+                row = df.iloc[idx].copy()
+                # Excel exports often use merged cells for headings. When these
+                # are read via ``pandas.read_excel`` the value only appears in
+                # the top-left cell of the merge while the remaining cells are
+                # ``NaN``.  Forward filling ensures that each column inherits the
+                # merged value so the header does not look empty in later
+                # processing.
+                row = row.ffill()
+                header_rows.append(row)
 
             # Check if there are any non-empty values in the header rows
             header_has_values = []


### PR DESCRIPTION
## Summary
- fix _base_clean_dataframe to expand merged header cells by forward filling

## Testing
- `pytest tests/test_corp_soo_cleaning.py::TestCorpSOOCleaning::test_corp_soo_clean -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68497e543dec8332887a11616fc201f9