### PR TITLE
Preserve zero-value Corp SOO rows

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1106,15 +1106,26 @@ class ExcelViewer(QWidget):
                 data_part = clean_df.iloc[:, 1:]
 
                 numeric_part = data_part.apply(pd.to_numeric, errors="coerce")
-                numeric_exists = numeric_part.notna().any(axis=1)
 
                 blank_mask = data_part.isna() | (
                     data_part.astype(str).apply(lambda x: x.str.strip() == "")
                 )
                 numeric_zero_mask = (numeric_part == 0) & numeric_part.notna()
 
-                empty_cond = (blank_mask | numeric_zero_mask).all(axis=1)
-                clean_df = clean_df.loc[~empty_cond]
+                first_col = clean_df.iloc[:, 0]
+                first_col_blank = first_col.isna() | (
+                    first_col.astype(str).str.strip() == ""
+                )
+
+                all_numeric_blank = blank_mask.all(axis=1)
+                all_numeric_blank_or_zero = (blank_mask | numeric_zero_mask).all(
+                    axis=1
+                )
+
+                remove_rows = (first_col_blank & all_numeric_blank_or_zero) | (
+                    (~first_col_blank) & all_numeric_blank
+                )
+                clean_df = clean_df.loc[~remove_rows]
             else:
                 clean_df = clean_df.loc[~((clean_df.isna().all(axis=1)) |
                                     (clean_df.astype(str).apply(lambda x: x.str.strip() == '').all(axis=1)))]

--- a/tests/test_corp_soo_cleaning.py
+++ b/tests/test_corp_soo_cleaning.py
@@ -29,9 +29,10 @@ class TestCorpSOOCleaning(unittest.TestCase):
         cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
         self.assertIsNotNone(cleaned)
         self.assertEqual(list(cleaned.columns), ['A','B','C'])
-        self.assertEqual(len(cleaned), 2)
+        self.assertEqual(len(cleaned), 3)
         self.assertEqual(cleaned.iloc[0].tolist(), ['acct2', 1.0, 2.0])
         self.assertEqual(cleaned.iloc[1].tolist(), ['acct2', 0, 'foo'])
+        self.assertEqual(cleaned.iloc[2].tolist(), ['acct3', 0, 0.0])
 
     def test_text_column_not_dropped(self):
         """Purely textual columns should be preserved when cleaning."""
@@ -54,8 +55,33 @@ class TestCorpSOOCleaning(unittest.TestCase):
         cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
         self.assertIsNotNone(cleaned)
         self.assertEqual(list(cleaned.columns), ['CAReportName', 'Val1', 'Val2'])
-        self.assertEqual(len(cleaned), 1)
-        self.assertEqual(cleaned.iloc[0].tolist(), ['TextB', 1.0, 2.0])
+        self.assertEqual(len(cleaned), 2)
+        self.assertEqual(cleaned.iloc[0].tolist(), ['TextA', 0, 0.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ['TextB', 1, 2.0])
+
+    def test_zero_numeric_rows_preserved(self):
+        """Rows with text in the first column and zero numeric values remain."""
+        from src.ui.excel_viewer import ExcelViewer
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            'header_rows': [0],
+            'skip_rows': 1,
+            'first_data_column': 2,
+            'description': ''
+        }
+        viewer.report_type = 'Corp SOO'
+
+        df = pd.DataFrame([
+            ['A', 'B', 'C'],
+            ['RowZero', 0, 0],
+            ['RowData', 1, 2]
+        ])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(len(cleaned), 2)
+        self.assertEqual(cleaned.iloc[0].tolist(), ['RowZero', 0, 0.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ['RowData', 1, 2.0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- keep rows in Corp SOO cleaning when first column has text and numeric columns are zero
- adjust Corp SOO cleaning tests for the new behavior
- add test verifying zero numeric rows are preserved

## Testing
- `pytest -q tests/test_corp_soo_cleaning.py::TestCorpSOOCleaning::test_zero_numeric_rows_preserved -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68498f1550848332b6810d03733cc312