### PR TITLE
Fix Corp SOO config and cleaning status

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ These options control how the `_clean_dataframe` helper processes sheets for tha
 
 The application ships with sensible defaults for many reports. In the default
 configuration the **Corp SOO** report uses `header_rows` `[5]` and `skip_rows`
-set to `6`, meaning the data begins on the seventh row of the sheet.
+set to `7`, meaning the data begins on the eighth row of the sheet.
+
+When Excel files are loaded the analyzer now automatically unmerges any merged
+cells.  The value from the top-left cell of a merged range is copied into all
+cells of that range before the data is handed off to `pandas`.  This ensures the
+cleaning logic works with consistent tabular data.
 
 For temp table query testing, you can use the specialized scripts:
 ```

--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1941,17 +1941,34 @@ class ExcelViewer(QWidget):
             
             # Get human-readable row descriptions (converting from 0-indexed to 1-indexed)
             header_rows_text = ", ".join([str(idx + 1) for idx in self.report_config["header_rows"]])
-            
+
+            # Build message elements based on report configuration
+            if len(self.report_config["header_rows"]) > 1:
+                header_note = f"- Headers from rows {header_rows_text} have been concatenated\n"
+            else:
+                header_note = f"- Header from row {header_rows_text} has been applied\n"
+
+            skip_note = (
+                f"- {self.report_config['skip_rows']} rows above the header have been removed\n"
+            )
+
+            sheet_col_note = ""
+            if self.report_type not in ("SOO MFR", "Corp SOO"):
+                sheet_col_note = "- A new column with the sheet name has been added\n"
+
             # Show a status message
             from PyQt6.QtWidgets import QMessageBox
-            QMessageBox.information(self, "Sheet Cleaned", 
+            QMessageBox.information(
+                self,
+                "Sheet Cleaned",
                 f"The sheet has been cleaned successfully using {self.report_config['description']}:\n"
-                f"- Headers from rows {header_rows_text} have been concatenated\n"
-                f"- {self.report_config['skip_rows']} rows above the header have been removed\n"
+                f"{header_note}"
+                f"{skip_note}"
                 f"- Blank rows have been removed\n"
                 f"- Completely empty columns have been removed\n"
-                f"- A new column with the sheet name has been added\n\n"
-                f"You can now double-click on column headers to edit them.")
+                f"{sheet_col_note}\n"
+                f"You can now double-click on column headers to edit them."
+            )
             
             return True
             

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -275,7 +275,7 @@ class AppConfig:
             },
             "Corp SOO": {
                 "header_rows": [5],
-                "skip_rows": 6,
+                "skip_rows": 7,
                 "first_data_column": 2,
                 "description": "Corporate SOO report with header on row 6"
             },

--- a/tests/test_report_configs.py
+++ b/tests/test_report_configs.py
@@ -113,7 +113,7 @@ class ReportConfigTests(unittest.TestCase):
                 cfg.get_report_config('Corp SOO'),
                 {
                     'header_rows': [5],
-                    'skip_rows': 6,
+                    'skip_rows': 7,
                     'first_data_column': 2,
                     'description': 'Corporate SOO report with header on row 6'
                 }


### PR DESCRIPTION
## Summary
- update Corp SOO report configuration so data begins on row 8
- improve the cleaning complete message so it reflects the actions performed
- adjust docs and tests for the new Corp SOO defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849942944708332ad1f4da901afd66b