### PR TITLE
Switch PDF generation to reportlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ python src/analyzer/run_real_query.py
 First save your comparison results to a CSV file. In the GUI this can be done
 via **File -> Export Results**. Scripts under `src/analyzer` can also write the
 output directly. Once you have a `results.csv` (see
-`sample_data/comparison_results.csv` for an example), run:
+`sample_data/comparison_results.csv` for an example), run the ReportLab-based
+generator:
 ```
 python src/reporting/generate_pdf_report.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "seaborn==0.13.0",
     "python-dotenv==1.0.0",
     "jinja2",
-    "weasyprint",
+    "reportlab",
     "plotly",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ matplotlib==3.8.2
 seaborn==0.13.0
 python-dotenv==1.0.0
 jinja2
-weasyprint
-plotly 
+reportlab
+plotly

--- a/src/reporting/generate_pdf_report.py
+++ b/src/reporting/generate_pdf_report.py
@@ -1,9 +1,19 @@
-import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-from jinja2 import Environment, FileSystemLoader
-from weasyprint import HTML
 import os
+from typing import List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Image,
+    Table,
+    TableStyle,
+)
 
 # CONFIGURATION
 REPORT_TITLE = "SOO Preclose Financial Report"
@@ -11,114 +21,103 @@ LOGO_PATH = "logo.png"  # Place your company logo here
 RESULTS_CSV = "results.csv"  # Path to your results data
 OUTPUT_PDF = "SOO_Preclose_Report.pdf"
 
-# 1. Load Data
-df = pd.read_csv(RESULTS_CSV)
 
-# 2. Generate Key Metrics Table (customize as needed)
-key_metrics = df.groupby('Center').agg({
-    'Variance': 'sum',
-    'Actual': 'sum',
-    'Budget': 'sum'
-}).reset_index()
-key_metrics.columns = ['Center', 'Total Variance', 'Total Actual', 'Total Budget']
+# Helper to build table data from a DataFrame
+def dataframe_to_table(df: pd.DataFrame) -> List[List[str]]:
+    table = [df.columns.tolist()]
+    for _, row in df.iterrows():
+        table.append([str(x) for x in row.tolist()])
+    return table
 
-# 3. Generate Visuals (example: Variance by Center)
-plt.figure(figsize=(10, 6))
-sns.barplot(data=key_metrics, x='Center', y='Total Variance', palette='Blues_d')
-plt.title('Variance by Center')
-plt.xticks(rotation=45, ha='right')
-plt.tight_layout()
-chart_path = 'variance_by_center.png'
-plt.savefig(chart_path, bbox_inches='tight', dpi=200)
-plt.close()
 
-# 4. Executive Summary (customize or automate as needed)
-summary_text = (
-    f"<b>Executive Summary:</b> <br>"
-    f"Total positive variance: <b>${key_metrics['Total Variance'].sum():,.2f}</b>.<br>"
-    f"Top performing center: <b>{key_metrics.loc[key_metrics['Total Variance'].idxmax(), 'Center']}</b>.<br>"
-    f"No centers flagged for material risk. All payroll tax % of wages within target."
-)
+def main() -> None:
+    # 1. Load Data
+    df = pd.read_csv(RESULTS_CSV)
 
-# 5. Prepare HTML Template
-TEMPLATE_DIR = os.path.dirname(os.path.abspath(__file__))
-env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    # 2. Generate Key Metrics Table
+    key_metrics = (
+        df.groupby("Center")[["Variance", "Actual", "Budget"]].sum().reset_index()
+    )
+    key_metrics.columns = [
+        "Center",
+        "Total Variance",
+        "Total Actual",
+        "Total Budget",
+    ]
 
-# Write the template file if it doesn't exist
-TEMPLATE_FILE = 'report_template.html'
-template_path = os.path.join(TEMPLATE_DIR, TEMPLATE_FILE)
-if not os.path.exists(template_path):
-    with open(template_path, 'w') as f:
-        f.write('''<!DOCTYPE html>
-<html>
-<head>
-    <style>
-        body { font-family: "Segoe UI", Arial, sans-serif; color: #222; }
-        h1, h2 { color: #2a4d69; }
-        table { border-collapse: collapse; width: 100%; margin-bottom: 30px; }
-        th, td { border: 1px solid #ccc; padding: 8px; text-align: right; }
-        th { background: #2a4d69; color: #fff; }
-        tr:nth-child(even) { background: #f2f2f2; }
-        .summary { background: #d9edf7; padding: 10px; border-radius: 5px; margin-bottom: 20px; }
-        .logo { width: 180px; }
-    </style>
-</head>
-<body>
-    {% if logo_path and logo_exists %}<img src="{{ logo_path }}" class="logo" />{% endif %}
-    <h1>{{ report_title }}</h1>
-    <div class="summary">
-        {{ summary_text|safe }}
-    </div>
-    <h2>Key Metrics</h2>
-    <table>
-        <tr>
-            {% for col in key_metrics.columns %}
-            <th>{{ col }}</th>
-            {% endfor %}
-        </tr>
-        {% for row in key_metrics.values %}
-        <tr>
-            {% for val in row %}
-            <td>{{ "{:,}".format(val) if val is number else val }}</td>
-            {% endfor %}
-        </tr>
-        {% endfor %}
-    </table>
-    <h2>Variance by Center</h2>
-    <img src="variance_by_center.png" style="width:100%;max-width:700px;" />
-    <h2>Detailed Results</h2>
-    <table>
-        <tr>
-            {% for col in df.columns %}
-            <th>{{ col }}</th>
-            {% endfor %}
-        </tr>
-        {% for row in df.values %}
-        <tr>
-            {% for val in row %}
-            <td>{{ val }}</td>
-            {% endfor %}
-        </tr>
-        {% endfor %}
-    </table>
-</body>
-</html>
-''')
+    # 3. Generate Visuals
+    plt.figure(figsize=(8, 4))
+    key_metrics.plot(
+        kind="bar",
+        x="Center",
+        y="Total Variance",
+        legend=False,
+        color="steelblue",
+    )
+    plt.title("Variance by Center")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    chart_path = "variance_by_center.png"
+    plt.savefig(chart_path, bbox_inches="tight", dpi=150)
+    plt.close()
 
-template = env.get_template(TEMPLATE_FILE)
+    # 4. Executive Summary (example text)
+    summary_text = (
+        f"Total positive variance: ${key_metrics['Total Variance'].sum():,.2f}. "
+        f"Top performing center: {key_metrics.loc[key_metrics['Total Variance'].idxmax(), 'Center']}."
+    )
 
-# 6. Render HTML
-html_out = template.render(
-    report_title=REPORT_TITLE,
-    logo_path=LOGO_PATH,
-    logo_exists=os.path.exists(LOGO_PATH),
-    summary_text=summary_text,
-    key_metrics=key_metrics,
-    df=df,
-    number=(int, float)
-)
+    # 5. Build PDF with ReportLab
+    doc = SimpleDocTemplate(OUTPUT_PDF, pagesize=letter)
+    styles = getSampleStyleSheet()
+    elements = []
 
-# 7. Export to PDF
-HTML(string=html_out, base_url=TEMPLATE_DIR).write_pdf(OUTPUT_PDF)
+    if os.path.exists(LOGO_PATH):
+        elements.append(Image(LOGO_PATH, width=180, height=60))
+        elements.append(Spacer(1, 12))
 
-print(f"PDF report generated: {OUTPUT_PDF}") 
+    elements.append(Paragraph(REPORT_TITLE, styles["Title"]))
+    elements.append(Spacer(1, 12))
+    elements.append(Paragraph(summary_text, styles["Normal"]))
+    elements.append(Spacer(1, 12))
+
+    # Key metrics table
+    km_table = Table(dataframe_to_table(key_metrics))
+    km_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2a4d69")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
+            ]
+        )
+    )
+    elements.append(km_table)
+    elements.append(Spacer(1, 12))
+
+    # Chart image
+    elements.append(Image(chart_path, width=400, height=250))
+    elements.append(Spacer(1, 12))
+
+    # Detailed results table
+    detail_table = Table(dataframe_to_table(df), repeatRows=1)
+    detail_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2a4d69")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    elements.append(detail_table)
+
+    doc.build(elements)
+
+    print(f"PDF report generated: {OUTPUT_PDF}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- drop `weasyprint` dependency
- use `reportlab` instead
- rewrite `generate_pdf_report.py` to use `reportlab` for PDF creation
- document the new PDF generation flow in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*
- `./scripts/install_test_deps.sh` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68507f426e648332bb8221beb1dacade