### PR TITLE
Update mismatch summary in PDF report

### DIFF
--- a/src/reporting/generate_pdf_report.py
+++ b/src/reporting/generate_pdf_report.py
@@ -35,12 +35,12 @@ def dataframe_to_table(df: pd.DataFrame) -> List[List[str]]:
 
 def main() -> None:
     # 1. Load Data
-    df_all = pd.read_csv(RESULTS_CSV)
+    df = pd.read_csv(RESULTS_CSV)
 
     # Calculate basic counts
-    total_points = len(df_all)
-    match_count = (df_all["Result"] == "Match").sum()
-    mismatch_df = df_all[df_all["Result"] != "Match"]
+    total_points = len(df)
+    match_count = (df["Result"] == "Match").sum()
+    mismatch_df = df[df["Result"] != "Match"]
     mismatch_count = len(mismatch_df)
 
     # Use only mismatches for the report


### PR DESCRIPTION
## Summary
- compute counts immediately after loading the CSV
- display counts beneath the report title and fixed subtitle
- use only mismatched rows for the remaining report generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68508d5fc3ec8332b644c333e3b6a8e3