### PR TITLE
Filter mismatched rows in PDF report

### DIFF
--- a/src/reporting/generate_pdf_report.py
+++ b/src/reporting/generate_pdf_report.py
@@ -106,7 +106,9 @@ def main() -> None:
     elements.append(Spacer(1, 12))
 
     # Detailed results table
-    detail_table = Table(dataframe_to_table(df), repeatRows=1)
+    # Only show rows where the Result column is not "Match"
+    mismatch_df = df[df["Result"] != "Match"]
+    detail_table = Table(dataframe_to_table(mismatch_df), repeatRows=1)
     detail_table.setStyle(
         TableStyle(
             [


### PR DESCRIPTION
## Summary
- filter out rows marked as `Match` when building the detailed table for the PDF report

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `./scripts/install_test_deps.sh` *(fails: Could not find a version that satisfies the requirement SQLAlchemy>=1.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_68508b4312408332bc245c5832f7e75a