### PR TITLE
Pass report type to report generators

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1810,7 +1810,10 @@ class MainWindow(QMainWindow):
         try:
             env = os.environ.copy()
             report_type = self.config.get("excel", "report_type")
-            env["REPORT_TITLE"] = report_type if report_type else ""
+            if report_type:
+                env["REPORT_TITLE"] = report_type
+            else:
+                env.pop("REPORT_TITLE", None)
             env["TESTING_NOTES_PATH"] = notes_path
             subprocess.run(["python", script_path], check=True, env=env)
             pdf_path = os.path.join(reporting_dir, "SOO_Preclose_Report.pdf")
@@ -1899,7 +1902,10 @@ class MainWindow(QMainWindow):
         try:
             env = os.environ.copy()
             report_type = self.config.get("excel", "report_type")
-            env["REPORT_TITLE"] = report_type if report_type else ""
+            if report_type:
+                env["REPORT_TITLE"] = report_type
+            else:
+                env.pop("REPORT_TITLE", None)
             env["TESTING_NOTES_PATH"] = notes_path
             subprocess.run(["python", script_path], check=True, env=env)
             html_path = os.path.join(reporting_dir, "SOO_Preclose_Report.html")


### PR DESCRIPTION
## Summary
- forward the selected report type as REPORT_TITLE when launching report generators
- fall back to default REPORT_TITLE if no report type is configured

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68519dd958548332b95e95a04d2290b3