### PR TITLE
Add issue column and environment title tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ python src/analyzer/run_real_query.py
 ### Generate the PDF report
 First save your comparison results to a CSV file. In the GUI this can be done
 via **File -> Export Results**. Scripts under `src/analyzer` can also write the
-output directly. Once you have a `results.csv` (see
+output directly. When exporting you will be prompted to enter optional testing
+notes which appear in the PDF and HTML reports. The exported CSV now includes a
+new **Issue** column describing each mismatch. Once you have a `results.csv` (see
 `sample_data/comparison_results.csv` for an example), run:
 ```
 python src/reporting/generate_pdf_report.py

--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -614,6 +614,8 @@ class ComparisonEngine:
                     'Variance': variance,
                     'Result': result,
                 }
+                # Describe any problem in a human readable form
+                row_data['Issue'] = result if result != 'Match' else ''
                 if include_sheet:
                     row_data['Sheet'] = sheet_name
                 if include_center:

--- a/src/reporting/generate_pdf_report.py
+++ b/src/reporting/generate_pdf_report.py
@@ -14,7 +14,7 @@ ACCENT_GRAY = "#E9ECEF"
 TEXT_GRAY = "#495057"
 
 # CONFIGURATION
-REPORT_TITLE = "SOO Preclose Financial Report"
+REPORT_TITLE = os.getenv("REPORT_TITLE", "SOO Preclose Financial Report")
 # Resolve paths relative to this file so it works regardless of the current
 # working directory.
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -26,6 +26,7 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         self.engine.set_sign_flip_accounts(['1234-5678'])
         df = self.engine.generate_detailed_comparison_dataframe('Sheet1', self.excel_df, sql_mod)
         self.assertIn('Does Not Match', df['Result'].values)
+        self.assertIn('Issue', df.columns)
 
     def test_identify_account_discrepancies(self):
         discrepancies = self.engine.identify_account_discrepancies(self.excel_df, self.sql_df)

--- a/tests/test_report_title_env.py
+++ b/tests/test_report_title_env.py
@@ -1,0 +1,21 @@
+import importlib
+import os
+import unittest
+
+class TestReportTitleEnv(unittest.TestCase):
+    def test_html_report_title_from_env(self):
+        env_title = "Custom HTML Title"
+        with unittest.mock.patch.dict(os.environ, {"REPORT_TITLE": env_title}):
+            module = importlib.import_module("src.reporting.generate_html_report")
+            importlib.reload(module)
+            self.assertEqual(module.REPORT_TITLE, env_title)
+
+    def test_pdf_report_title_from_env(self):
+        env_title = "Custom PDF Title"
+        with unittest.mock.patch.dict(os.environ, {"REPORT_TITLE": env_title}):
+            module = importlib.import_module("src.reporting.generate_pdf_report")
+            importlib.reload(module)
+            self.assertEqual(module.REPORT_TITLE, env_title)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- include 'Issue' column when generating detailed comparison results
- pull REPORT_TITLE from env in PDF report generator
- assert Issue column exists in comparison engine tests
- add tests for REPORT_TITLE env variable usage
- document new Issue column and notes prompt in README

## Testing
- `./scripts/install_test_deps.sh` *(fails: could not download packages)*
- `pytest -q` *(fails: ModuleNotFoundError for pandas and others)*

------
https://chatgpt.com/codex/tasks/task_e_6851a1baebb083328ee157d616bb99e4