### PR TITLE
Clarify Issue column usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ python src/analyzer/run_real_query.py
 First save your comparison results to a CSV file. In the GUI this can be done
 via **File -> Export Results**. Scripts under `src/analyzer` can also write the
 output directly. When exporting you will be prompted to enter optional testing
-notes which appear in the PDF and HTML reports. The exported CSV now includes a
-new **Issue** column describing each mismatch. Once you have a `results.csv` (see
-`sample_data/comparison_results.csv` for an example), run:
+notes which appear in the PDF and HTML reports. You may also add an optional
+**Issue** column describing each mismatch. The report scripts handle this field
+if present. Once you have a `results.csv` (see `sample_data/comparison_results.csv`
+for an example that includes the column), run:
 ```
 python src/reporting/generate_pdf_report.py
 ```


### PR DESCRIPTION
## Summary
- clarify that the `Issue` column in results CSV is optional
- point readers to the example CSV that includes the column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851a6aa65b483328ef512f075dae637