### PR TITLE
Revamp HTML report layout

### DIFF
--- a/src/reporting/generate_html_report.py
+++ b/src/reporting/generate_html_report.py
@@ -67,40 +67,123 @@ def main() -> None:
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset='UTF-8'>
-<title>{REPORT_TITLE}</title>
-<style>
-body {{ font-family: Arial, sans-serif; color: {BRAND_BLUE}; margin: 20px; }}
-.container {{ max-width: 750px; margin:auto; }}
-.cards {{ display:flex; justify-content: space-between; margin-bottom:20px; }}
-.card {{ flex:1; background:#f5f5f5; border-radius:6px; padding:10px; margin:0 5px; text-align:center; }}
-.card-value {{ font-size:20px; font-weight:bold; }}
-.chart {{ text-align:center; margin-bottom:20px; }}
-.table-container {{ overflow-x:auto; }}
-table {{ border-collapse:collapse; width:100%; }}
-th, td {{ border:1px solid #ddd; padding:4px; max-width:150px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }}
-th {{ background:{BRAND_BLUE}; color:white; }}
-tr:nth-child(even) {{ background:#f9f9f9; }}
-</style>
+    <meta charset='UTF-8'>
+    <title>{REPORT_TITLE}</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+        body {{
+            font-family: 'Inter', sans-serif;
+            color: {BRAND_BLUE};
+            margin: 0;
+            padding: 1.5rem;
+            background: #fff;
+        }}
+
+        .container {{
+            max-width: 900px;
+            margin: auto;
+        }}
+
+        .metrics {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }}
+
+        .metric-card {{
+            background: #F8F9FA;
+            border-radius: 10px;
+            padding: 1rem;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            border-top: 4px solid {BRAND_BLUE};
+            text-align: center;
+        }}
+
+        .metric-title {{
+            font-size: 14px;
+            text-transform: uppercase;
+            color: {BRAND_BLUE};
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+        }}
+
+        .metric-value {{
+            font-size: 22px;
+            font-weight: 600;
+            color: {BRAND_BLUE};
+        }}
+
+        .chart {{
+            text-align: center;
+            margin-bottom: 2rem;
+        }}
+
+        .table-container {{
+            overflow-x: auto;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            border-radius: 8px;
+        }}
+
+        table {{
+            border-collapse: collapse;
+            width: 100%;
+            font-size: 14px;
+        }}
+
+        th {{
+            background: {BRAND_BLUE};
+            color: white;
+            padding: 0.75rem;
+            text-align: left;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }}
+
+        td {{
+            padding: 0.5rem;
+            border-bottom: 1px solid #E9ECEF;
+            max-width: 200px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }}
+
+        tr:nth-child(even) {{
+            background: #F8F9FA;
+        }}
+    </style>
 </head>
 <body>
-<div class='container'>
-<h1>{REPORT_TITLE}</h1>
-<div class='cards'>
-<div class='card'><div>Total Data Points</div><div class='card-value'>{total_points}</div></div>
-<div class='card'><div>Total Matches</div><div class='card-value'>{total_matches}</div></div>
-<div class='card'><div>Total Mismatches</div><div class='card-value'>{total_mismatches}</div></div>
-</div>
-<div class='chart'><img src='data:image/png;base64,{img_data}' alt='Match Chart'></div>
-{notes_html}
-<h2>Mismatches</h2>
-<div class='table-container'>
-<table>
-<tr>{table_headers}</tr>
-{table_rows}
-</table>
-</div>
-</div>
+    <div class='container'>
+        <h1>{REPORT_TITLE}</h1>
+        <div class='metrics'>
+            <div class='metric-card'>
+                <div class='metric-title'>Total Data Points</div>
+                <div class='metric-value'>{total_points}</div>
+            </div>
+            <div class='metric-card'>
+                <div class='metric-title'>Total Matches</div>
+                <div class='metric-value'>{total_matches}</div>
+            </div>
+            <div class='metric-card'>
+                <div class='metric-title'>Total Mismatches</div>
+                <div class='metric-value'>{total_mismatches}</div>
+            </div>
+        </div>
+        <div class='chart'>
+            <img src='data:image/png;base64,{img_data}' alt='Match Chart'>
+        </div>
+        {notes_html}
+        <h2>Mismatches</h2>
+        <div class='table-container'>
+            <table>
+                <tr>{table_headers}</tr>
+                {table_rows}
+            </table>
+        </div>
+    </div>
 </body>
 </html>
 """


### PR DESCRIPTION
## Summary
- modernize HTML report style to match PDF
- include Inter font and card-styled metric display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851a7bc162083328be6b0b6276bd4d2