### PR TITLE
Enable category actions after running SQL

### DIFF
--- a/src/ui/account_category_dialog.py
+++ b/src/ui/account_category_dialog.py
@@ -70,6 +70,13 @@ class AccountCategoryDialog(QDialog):
 
         self._init_ui()
 
+    def refresh_accounts(self, accounts) -> None:
+        """Refresh available accounts using ``accounts`` and current categories."""
+        category_accounts = {acct for lst in self.categories.values() for acct in lst}
+        self.all_accounts = sorted(set(accounts or []) | category_accounts)
+        current = self._current_accounts()
+        self._populate_account_list(current)
+
     def _refresh_drag_categories(self) -> None:
         """Update the list of categories available for drag-and-drop."""
         if hasattr(self, "category_drag_list"):


### PR DESCRIPTION
## Summary
- allow managing account categories in the toolbar only after SQL results are loaded
- prompt the user to manage categories after executing SQL
- refresh account lists when opening the AccountCategoryDialog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68654e323d1c8332a0e7c8bd9d724cc8