### PR TITLE
Handle text account names in CategoryCalculator

### DIFF
--- a/src/utils/account_categories.py
+++ b/src/utils/account_categories.py
@@ -192,6 +192,22 @@ class CategoryCalculator:
                                 else:
                                     totals[group_val][name][col] += Decimal(str(val))
                         break
+                    elif not acct_code and not cat_code:
+                        if acct_raw.strip().lower() == str(acc).strip().lower():
+                            for col in numeric_cols:
+                                val = row.get(col)
+                                if isinstance(
+                                    val, (int, float, Decimal)
+                                ) and not isinstance(val, bool):
+                                    if sign_flip.should_flip(
+                                        acct_raw, self.sign_flip_accounts
+                                    ):
+                                        val = -val
+                                    if isinstance(val, Decimal):
+                                        totals[group_val][name][col] += val
+                                    else:
+                                        totals[group_val][name][col] += Decimal(str(val))
+                            break
 
             for acc in account_refs:
                 acc_code = self._extract_account_code(acc)

--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -301,6 +301,24 @@ class TestCategoryCalculator(unittest.TestCase):
         profit = next(r for r in result if r["CAReportName"] == "Net Profit")
         self.assertEqual(profit["Amount"], -50)
 
+    def test_non_numeric_account_names(self):
+        rows = [
+            {"CAReportName": "Salaries", "Amount": 100},
+            {"CAReportName": "benefits", "Amount": 50},
+            {"CAReportName": "Other", "Amount": 10},
+        ]
+        categories = {"Labor": ["Salaries", "Benefits"]}
+        formulas = {"Total": "Labor"}
+
+        calc = CategoryCalculator(categories, formulas)
+        result = calc.compute(rows)
+
+        labor = next(r for r in result if r["CAReportName"] == "Labor")
+        self.assertEqual(labor["Amount"], 150)
+
+        total = next(r for r in result if r["CAReportName"] == "Total")
+        self.assertEqual(total["Amount"], 150)
+
 
 class TestAccountCategoryDialog(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- aggregate account categories when both account codes are missing but the raw strings match ignoring case
- test that accounts with text names work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686558749bb48332a1fd8325a648402c