### PR TITLE
Improve sheet-based grouping

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1735,9 +1735,14 @@ class MainWindow(QMainWindow):
                 categories = self.config.get_account_categories(report_type)
                 formulas = self.config.get_account_formulas(report_type)
                 if categories:
-                    group_col = (
-                        "Center" if "Center" in filtered_sql_df.columns else None
-                    )
+                    group_col = None
+                    cols_lower = {c.lower(): c for c in filtered_sql_df.columns}
+                    for cand in ["sheet", "sheet_name", "sheet name"]:
+                        if cand.lower() in cols_lower:
+                            group_col = cols_lower[cand.lower()]
+                            break
+                    if group_col is None and "Center" in filtered_sql_df.columns:
+                        group_col = "Center"
                     sign_flip = list(
                         getattr(self.comparison_engine, "sign_flip_accounts", [])
                     )
@@ -1826,9 +1831,14 @@ class MainWindow(QMainWindow):
                 categories = self.config.get_account_categories(report_type)
                 formulas = self.config.get_account_formulas(report_type)
                 if categories:
-                    group_col = (
-                        "Center" if "Center" in filtered_sql_df.columns else None
-                    )
+                    group_col = None
+                    cols_lower = {c.lower(): c for c in filtered_sql_df.columns}
+                    for cand in ["sheet", "sheet_name", "sheet name"]:
+                        if cand.lower() in cols_lower:
+                            group_col = cols_lower[cand.lower()]
+                            break
+                    if group_col is None and "Center" in filtered_sql_df.columns:
+                        group_col = "Center"
                     sign_flip = list(
                         getattr(self.comparison_engine, "sign_flip_accounts", [])
                     )
@@ -1922,7 +1932,14 @@ class MainWindow(QMainWindow):
                 categories = self.config.get_account_categories(report_type)
                 formulas = self.config.get_account_formulas(report_type)
                 if categories:
-                    group_col = "Center" if "Center" in filtered_sql_df.columns else None
+                    group_col = None
+                    cols_lower = {c.lower(): c for c in filtered_sql_df.columns}
+                    for cand in ["sheet", "sheet_name", "sheet name"]:
+                        if cand.lower() in cols_lower:
+                            group_col = cols_lower[cand.lower()]
+                            break
+                    if group_col is None and "Center" in filtered_sql_df.columns:
+                        group_col = "Center"
                     sign_flip = list(getattr(self.comparison_engine, "sign_flip_accounts", []))
                     calc = CategoryCalculator(
                         categories,

--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -360,7 +360,13 @@ class ResultsViewer(QWidget):
                 if categories:
                     group_col = None
                     if self.results_data and isinstance(self.results_data[0], dict):
-                        if "Center" in self.results_data[0]:
+                        first_row = self.results_data[0]
+                        lower_map = {k.lower(): k for k in first_row}
+                        for cand in ["sheet", "sheet_name", "sheet name"]:
+                            if cand.lower() in lower_map:
+                                group_col = lower_map[cand.lower()]
+                                break
+                        if group_col is None and "Center" in first_row:
                             group_col = "Center"
                     sign_flip = []
                     if parent and hasattr(parent, "comparison_engine"):


### PR DESCRIPTION
## Summary
- support grouping calculations by sheet name
- apply same grouping logic in main window
- ensure formula rows show sheet names in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68655b6a84808332986566267d957592