### PR TITLE
Ensure Sheet_Name grouping in results viewer

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -358,6 +358,24 @@ class ResultsViewer(QWidget):
                 categories = parent.config.get_account_categories(report_type)
                 formulas = parent.config.get_account_formulas(report_type)
                 if categories:
+                    sheet_added = False
+                    if self.results_data and isinstance(self.results_data[0], dict):
+                        first_row = self.results_data[0]
+                        if "Sheet_Name" not in first_row:
+                            sheet_added = True
+                            sheet_val = ""
+                            if parent and hasattr(parent, "sheet_selector"):
+                                try:
+                                    sheet_val = parent.sheet_selector.currentText()
+                                except Exception:
+                                    sheet_val = ""
+                            if not sheet_val and hasattr(parent, "config"):
+                                sheet_val = parent.config.get("excel", "sheet_name") or ""
+                            for row in self.results_data:
+                                row["Sheet_Name"] = sheet_val
+                            if "Sheet_Name" not in self.columns:
+                                self.columns = ["Sheet_Name"] + list(self.columns)
+
                     group_col = None
                     if self.results_data and isinstance(self.results_data[0], dict):
                         first_row = self.results_data[0]
@@ -368,6 +386,8 @@ class ResultsViewer(QWidget):
                                 break
                         if group_col is None and "Center" in first_row:
                             group_col = "Center"
+                    if sheet_added:
+                        group_col = "Sheet_Name"
                     sign_flip = []
                     if parent and hasattr(parent, "comparison_engine"):
                         sign_flip = list(

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -89,6 +89,8 @@ class ApplyCalculationsTest(unittest.TestCase):
         parent.config.set_account_formulas("Test", {"Net": "CatA + CatB"})
         parent.config.report_type = "Test"
         parent.comparison_engine = type("CE", (), {"sign_flip_accounts": []})()
+        parent.sheet_selector = DummySelector("Foo")
+        parent.sheet_selector = DummySelector("Foo")
 
         viewer = self.ResultsViewer.__new__(self.ResultsViewer)
         viewer.results_data = [
@@ -105,12 +107,24 @@ class ApplyCalculationsTest(unittest.TestCase):
         calc = CategoryCalculator(
             {"CatA": ["1234-5678"], "CatB": ["9999-0000"]},
             {"Net": "CatA + CatB"},
-            group_column="Center",
+            group_column="Sheet_Name",
         )
-        expected = calc.compute([
-            {"Center": 1, "CAReportName": "1234-5678", "Amount": -100},
-            {"Center": 2, "CAReportName": "9999-0000", "Amount": 50},
-        ])
+        expected = calc.compute(
+            [
+                {
+                    "Sheet_Name": "Foo",
+                    "Center": 1,
+                    "CAReportName": "1234-5678",
+                    "Amount": -100,
+                },
+                {
+                    "Sheet_Name": "Foo",
+                    "Center": 2,
+                    "CAReportName": "9999-0000",
+                    "Amount": 50,
+                },
+            ]
+        )
 
         self.assertEqual(viewer.results_data, expected)
         self.assertIsInstance(viewer.model, self.ResultsTableModel)
@@ -118,6 +132,7 @@ class ApplyCalculationsTest(unittest.TestCase):
             viewer.status_label.text,
             f"{len(expected)} rows, {len(viewer.columns)} columns returned",
         )
+        self.assertIn("Sheet_Name", viewer.columns)
 
     def test_apply_calculations_groups_by_sheet(self):
         parent = self.MainWindow.__new__(self.MainWindow)
@@ -164,6 +179,7 @@ class ApplyCalculationsTest(unittest.TestCase):
         self.assertEqual(viewer.results_data, expected)
         sheets = {row.get("Sheet_Name") for row in viewer.results_data if row.get("CAReportName") == "Net"}
         self.assertEqual(sheets, {"Foo", "Bar"})
+        self.assertIn("Sheet_Name", viewer.columns)
 
 
 class SQLAccountExtractionTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- always inject a `Sheet_Name` column when missing in results
- group category calculations by the new column when added
- refresh the table model with the updated columns
- update unit tests for the new Sheet_Name behaviour

## Testing
- `pytest tests/test_results_viewer.py::ApplyCalculationsTest::test_apply_calculations_appends_rows -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686572eda78483329cd0ba6f2d2e8ecb