### PR TITLE
Add sheet-aware account category editor

### DIFF
--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -18,17 +18,25 @@ class DummyConfig:
         self.categories = {}
         self.formulas = {}
 
-    def get_account_categories(self, report_type):
-        return self.categories.get(report_type, {})
+    def get_account_categories(self, report_type, sheet_name=None):
+        mapping = self.categories.get(report_type, {})
+        if sheet_name is None:
+            return mapping.get("__default__", {})
+        return mapping.get(sheet_name, {})
 
-    def get_account_formulas(self, report_type):
-        return self.formulas.get(report_type, {})
+    def get_account_formulas(self, report_type, sheet_name=None):
+        mapping = self.formulas.get(report_type, {})
+        if sheet_name is None:
+            return mapping.get("__default__", {})
+        return mapping.get(sheet_name, {})
 
-    def set_account_categories(self, report_type, cats):
-        self.categories[report_type] = cats
+    def set_account_categories(self, report_type, cats, sheet_name=None):
+        sheet_name = sheet_name or "__default__"
+        self.categories.setdefault(report_type, {})[sheet_name] = cats
 
-    def set_account_formulas(self, report_type, formulas):
-        self.formulas[report_type] = formulas
+    def set_account_formulas(self, report_type, formulas, sheet_name=None):
+        sheet_name = sheet_name or "__default__"
+        self.formulas.setdefault(report_type, {})[sheet_name] = formulas
 
 
 class TestCategoryCalculator(unittest.TestCase):
@@ -330,7 +338,7 @@ class TestAccountCategoryDialog(unittest.TestCase):
     def test_account_list_populated(self):
         accounts = ["1111", "2222", "3333"]
         config = DummyConfig()
-        dialog = self.Dialog(config, "Test", accounts)
+        dialog = self.Dialog(config, "Test", accounts, sheet_names=["Sheet1"])
         from PyQt6.QtCore import Qt
 
         self.assertEqual(dialog.account_list.count(), len(accounts))
@@ -347,7 +355,7 @@ class TestAccountCategoryDialog(unittest.TestCase):
     def test_accounts_sorted_after_add(self):
         accounts = ["2222", "3333"]
         config = DummyConfig()
-        dialog = self.Dialog(config, "Test", accounts)
+        dialog = self.Dialog(config, "Test", accounts, sheet_names=["Sheet1"])
         from PyQt6.QtWidgets import QInputDialog
 
         def fake_get_text(*args, **kwargs):
@@ -364,7 +372,7 @@ class TestAccountCategoryDialog(unittest.TestCase):
 
     def test_add_delete_and_save(self):
         config = DummyConfig()
-        dialog = self.Dialog(config, "Test", [])
+        dialog = self.Dialog(config, "Test", [], sheet_names=["Sheet1"])
 
         from PyQt6.QtWidgets import QInputDialog
 
@@ -386,7 +394,7 @@ class TestAccountCategoryDialog(unittest.TestCase):
         config.set_account_categories("Test", {"Orig": ["1"]})
         config.set_account_formulas("Test", {"F": "Orig"})
 
-        dialog = self.Dialog(config, "Test", [])
+        dialog = self.Dialog(config, "Test", [], sheet_names=["Sheet1"])
 
         dialog.category_list.setCurrentRow(0)
         dialog._delete_category()

--- a/tests/test_open_account_categories_sql.py
+++ b/tests/test_open_account_categories_sql.py
@@ -10,10 +10,10 @@ FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 
 class DummyConfig:
-    def get_account_categories(self, report_type):
+    def get_account_categories(self, report_type, sheet_name=None):
         return {}
 
-    def get_account_formulas(self, report_type):
+    def get_account_formulas(self, report_type, sheet_name=None):
         return {}
 
 
@@ -50,8 +50,9 @@ class TestOpenAccountCategoriesSQL(unittest.TestCase):
         captured = {}
 
         class StubDialog:
-            def __init__(self, config, report_type, accounts, parent=None):
+            def __init__(self, config, report_type, accounts, sheet_names=None, parent=None):
                 captured['accounts'] = accounts
+                captured['sheets'] = sheet_names
             def exec(self):
                 return True
 
@@ -71,6 +72,7 @@ class TestOpenAccountCategoriesSQL(unittest.TestCase):
         window.open_account_categories()
 
         self.assertEqual(captured.get('accounts'), ['1234-5678', '9999-0000'])
+        self.assertEqual(captured.get('sheets'), [])
         self.assertEqual(window.status_bar.message, 'Account categories updated')
 
 

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -17,17 +17,19 @@ class DummyConfig:
         self.formulas = {}
         self.report_type = ""
 
-    def get_account_categories(self, report_type):
-        return self.categories.get(report_type, {})
+    def get_account_categories(self, report_type, sheet_name=None):
+        return self.categories.get(report_type, {}).get(sheet_name or '__default__', {})
 
-    def get_account_formulas(self, report_type):
-        return self.formulas.get(report_type, {})
+    def get_account_formulas(self, report_type, sheet_name=None):
+        return self.formulas.get(report_type, {}).get(sheet_name or '__default__', {})
 
-    def set_account_categories(self, report_type, cats):
-        self.categories[report_type] = cats
+    def set_account_categories(self, report_type, cats, sheet_name=None):
+        sheet_name = sheet_name or '__default__'
+        self.categories.setdefault(report_type, {})[sheet_name] = cats
 
-    def set_account_formulas(self, report_type, formulas):
-        self.formulas[report_type] = formulas
+    def set_account_formulas(self, report_type, formulas, sheet_name=None):
+        sheet_name = sheet_name or '__default__'
+        self.formulas.setdefault(report_type, {})[sheet_name] = formulas
 
     def get(self, section, key=None):
         if section == "excel" and key == "report_type":
@@ -206,8 +208,9 @@ class SQLAccountExtractionTest(unittest.TestCase):
         captured = {}
 
         class StubDialog:
-            def __init__(self, config, report_type, accounts, parent=None):
+            def __init__(self, config, report_type, accounts, sheet_names=None, parent=None):
                 captured["accounts"] = accounts
+                captured["sheets"] = sheet_names
 
             def refresh_accounts(self, accounts):
                 captured["refresh"] = accounts
@@ -233,6 +236,7 @@ class SQLAccountExtractionTest(unittest.TestCase):
 
         self.assertEqual(captured.get("accounts"), ["1234-5678", "9999-0000"])
         self.assertEqual(captured.get("refresh"), ["1234-5678", "9999-0000"])
+        self.assertEqual(captured.get("sheets"), [])
         self.assertEqual(window.status_bar.message, "Account categories updated")
 
 


### PR DESCRIPTION
## Summary
- allow editing categories per sheet via a new selector
- persist categories/formulas by sheet
- provide sheet names when opening the dialog
- update tests for sheet-aware dialog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68658f27331883328fd6185146faf65a