### PR TITLE
Fix SQL account extraction logic

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1519,20 +1519,6 @@ class MainWindow(QMainWindow):
         if not getattr(self, "results_viewer", None) or not self.results_viewer.has_results():
             return []
 
-    def _gather_sheet_names_from_sql(self):
-        """Return sheet names present in the SQL results if available."""
-        if not getattr(self, "results_viewer", None) or not self.results_viewer.has_results():
-            return []
-        try:
-            df = self.results_viewer.get_dataframe()
-            for cand in ["Sheet_Name", "Sheet", "SheetName"]:
-                if cand in df.columns:
-                    series = df[cand].dropna().astype(str)
-                    return sorted(series.unique().tolist())
-        except Exception as e:
-            self.logger.error(f"Failed to extract sheet names from SQL results: {e}")
-        return []
-
         from src.utils.account_patterns import ACCOUNT_PATTERNS
         patterns = ACCOUNT_PATTERNS
 
@@ -1541,7 +1527,7 @@ class MainWindow(QMainWindow):
             if df.empty:
                 return []
 
-            # Prefer a CAReportName column if present
+            # Prefer a CAReportName column if present (case-insensitive)
             for col in df.columns:
                 if str(col).lower() == "careportname".lower():
                     series = df[col].dropna().astype(str)
@@ -1558,6 +1544,20 @@ class MainWindow(QMainWindow):
         except Exception as e:
             self.logger.error(f"Failed to extract accounts from SQL results: {e}")
             return []
+
+    def _gather_sheet_names_from_sql(self):
+        """Return sheet names present in the SQL results if available."""
+        if not getattr(self, "results_viewer", None) or not self.results_viewer.has_results():
+            return []
+        try:
+            df = self.results_viewer.get_dataframe()
+            for cand in ["Sheet_Name", "Sheet", "SheetName"]:
+                if cand in df.columns:
+                    series = df[cand].dropna().astype(str)
+                    return sorted(series.unique().tolist())
+        except Exception as e:
+            self.logger.error(f"Failed to extract sheet names from SQL results: {e}")
+        return []
 
     def show_about(self):
         """Show about dialog"""

--- a/tests/test_gather_accounts_sql.py
+++ b/tests/test_gather_accounts_sql.py
@@ -49,6 +49,24 @@ class TestGatherAccountsSQL(unittest.TestCase):
         accounts = window._gather_accounts_from_sql()
         self.assertEqual(accounts, ['Alpha', 'Beta'])
 
+    def test_fallback_scans_all_columns(self):
+        df = pd.DataFrame({
+            'Acct': ['1234-5678', '9999-0000'],
+            'Amount': [1, 2],
+        })
+        rv = types.SimpleNamespace(
+            results_data=df.to_dict(orient='records'),
+            get_dataframe=lambda: df,
+            has_results=lambda: True,
+        )
+
+        window = self.MainWindow.__new__(self.MainWindow)
+        window.results_viewer = rv
+        window.logger = MagicMock()
+
+        accounts = window._gather_accounts_from_sql()
+        self.assertEqual(accounts, ['1234-5678', '9999-0000'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -206,6 +206,23 @@ class SQLAccountExtractionTest(unittest.TestCase):
 
         self.assertEqual(accounts, ["1234-5678", "9999-0000"])
 
+    def test_gather_accounts_sql_fallback(self):
+        df = pd.DataFrame({
+            "Acct": ["1234-5678", "9999-0000"],
+            "Amount": [1, 2],
+        })
+        window = self.MainWindow.__new__(self.MainWindow)
+        window.results_viewer = types.SimpleNamespace(
+            results_data=df.to_dict(orient="records"),
+            get_dataframe=lambda: df,
+            has_results=lambda: True,
+        )
+        window.logger = types.SimpleNamespace(error=lambda *a, **k: None)
+
+        accounts = window._gather_accounts_from_sql()
+
+        self.assertEqual(accounts, ["1234-5678", "9999-0000"])
+
     def test_open_account_categories_after_sql(self):
         captured = {}
 


### PR DESCRIPTION
## Summary
- restore SQL account gathering logic in `MainWindow`
- add fallback and case-insensitive logic tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865a0b39b7883328f73404e9b13c754