### PR TITLE
Fix SQL sheet name detection and add tests

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1551,12 +1551,16 @@ class MainWindow(QMainWindow):
             return []
         try:
             df = self.results_viewer.get_dataframe()
-            for cand in ["Sheet_Name", "Sheet", "SheetName"]:
-                if cand in df.columns:
-                    series = df[cand].dropna().astype(str)
+            lower_map = {str(col).lower(): col for col in df.columns}
+            for cand in ["sheet_name", "sheet", "sheetname"]:
+                if cand in lower_map:
+                    col = lower_map[cand]
+                    series = df[col].dropna().astype(str)
                     return sorted(series.unique().tolist())
         except Exception as e:
-            self.logger.error(f"Failed to extract sheet names from SQL results: {e}")
+            self.logger.error(
+                f"Failed to extract sheet names from SQL results: {e}"
+            )
         return []
 
     def show_about(self):

--- a/tests/test_gather_sheet_names_sql.py
+++ b/tests/test_gather_sheet_names_sql.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import types
+import unittest
+import pandas as pd
+
+from tests.qt_stubs import patch_qt_modules
+
+
+class TestGatherSheetNamesSQL(unittest.TestCase):
+    def setUp(self):
+        patch_qt_modules()
+        from importlib import import_module
+        sys.modules.pop('src.ui.main_window', None)
+        self.MainWindow = import_module('src.ui.main_window').MainWindow
+
+    def _gather(self, df):
+        window = self.MainWindow.__new__(self.MainWindow)
+        window.results_viewer = types.SimpleNamespace(
+            results_data=df.to_dict(orient='records'),
+            get_dataframe=lambda: df,
+            has_results=lambda: True,
+        )
+        window.logger = types.SimpleNamespace(error=lambda *a, **k: None)
+        return window._gather_sheet_names_from_sql()
+
+    def test_lowercase_column_names(self):
+        for cand in ["sheet_name", "sheet", "sheetname"]:
+            df = pd.DataFrame({cand: ["Foo", "Bar", "Foo"], "Amount": [1, 2, 3]})
+            sheets = self._gather(df)
+            self.assertEqual(sheets, ["Bar", "Foo"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle lowercase sheet name columns in SQL results
- add tests for lowercase sheet name columns

## Testing
- `pytest tests/test_gather_sheet_names_sql.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865a48d39f88332bf024f35274bf207