### PR TITLE
Add include_categories option

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -378,7 +378,11 @@ class ResultsViewer(QWidget):
                     if sheet_col and sheet_col not in self.results_data[0]:
                         default_group = sheet_val
                     base_data = self.original_data or self.results_data
-                    self.results_data = calc.compute(list(base_data), default_group=default_group)
+                    self.results_data = calc.compute(
+                        list(base_data),
+                        default_group=default_group,
+                        include_categories=False,
+                    )
 
         # Refresh the table model with new rows
         self.model = ResultsTableModel(self.results_data, self.columns)

--- a/src/utils/account_categories.py
+++ b/src/utils/account_categories.py
@@ -112,7 +112,10 @@ class CategoryCalculator:
         return ""
 
     def compute(
-        self, rows: List[Dict[str, Any]], default_group: Any | None = None
+        self,
+        rows: List[Dict[str, Any]],
+        default_group: Any | None = None,
+        include_categories: bool = True,
     ) -> List[Dict[str, Any]]:
         """Return rows extended with category totals and formula rows.
 
@@ -122,6 +125,12 @@ class CategoryCalculator:
         missing from ``rows``, the value of ``default_group`` will be used for
         all generated rows and inserted into the original rows so that the
         output always includes the grouping column.
+
+        Parameters
+        ----------
+        include_categories:
+            When ``True`` (default), append totals for each configured
+            category.  When ``False``, only rows for formulas are returned.
         """
         if not rows:
             return []
@@ -239,11 +248,12 @@ class CategoryCalculator:
                     break
 
         for g in groups:
-            for name in self.categories:
-                row_vals = {account_col: name, **totals[g][name]}
-                if group_exists:
-                    row_vals[self.group_column] = g
-                result.append(row_vals)
+            if include_categories:
+                for name in self.categories:
+                    row_vals = {account_col: name, **totals[g][name]}
+                    if group_exists:
+                        row_vals[self.group_column] = g
+                    result.append(row_vals)
 
             for form_name, expr in self.formulas.items():
                 # Replace category names and account refs with safe identifiers

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -125,7 +125,8 @@ class ApplyCalculationsTest(unittest.TestCase):
                     "CAReportName": "9999-0000",
                     "Amount": 50,
                 },
-            ]
+            ],
+            include_categories=False,
         )
 
         self.assertEqual(viewer.results_data, expected)
@@ -175,7 +176,8 @@ class ApplyCalculationsTest(unittest.TestCase):
             [
                 {"Sheet": "Foo", "CAReportName": "1234-5678", "Amount": -100},
                 {"Sheet": "Bar", "CAReportName": "9999-0000", "Amount": 50},
-            ]
+            ],
+            include_categories=False,
         )
 
         self.assertEqual(viewer.results_data, expected)


### PR DESCRIPTION
## Summary
- allow skipping category total rows via `include_categories` arg
- skip category rows when applying calculations in ResultsViewer
- adjust ResultsViewer tests for new behavior

## Testing
- `pytest -q` *(fails: pandas & sqlalchemy missing)*

------
https://chatgpt.com/codex/tasks/task_e_686691ce5ee48332a3d439ed10fc8971