### PR TITLE
Prefix sheet name on AR Center CAReportName

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1138,10 +1138,10 @@ class ExcelViewer(QWidget):
                     clean_df.iloc[:, idx], errors="coerce"
                 ).round(2)
 
-            # Add a new column with the sheet name at the beginning
-            # Skip this for SOO MFR and Corp SOO where including the sheet name would
-            # interfere with comparisons.
-            if self.report_type not in ("SOO MFR", "Corp SOO"):
+            # Add a new column with the sheet name at the beginning.
+            # Skip this for SOO MFR, Corp SOO and AR Center where including the
+            # sheet name would interfere with comparisons.
+            if self.report_type not in ("SOO MFR", "Corp SOO", "AR Center"):
                 clean_df.insert(0, "Sheet_Name", sheet_name)
 
             return clean_df
@@ -1884,19 +1884,26 @@ class ExcelViewer(QWidget):
 
             return clean_df
 
-        # Prefix account names with the sheet for AR Center reports
+        # Prefix account names with the sheet name for AR Center reports. If the
+        # CAReportName column cannot be found, fall back to the first column
+        # after cleaning.
         if self.report_type == "AR Center":
             ca_col = None
             for col in clean_df.columns:
                 if str(col).strip().replace(" ", "").lower() == "careportname":
                     ca_col = col
                     break
+            if ca_col is None and len(clean_df.columns) > 0:
+                ca_col = clean_df.columns[0]
+
             if ca_col:
                 prefix = f"{sheet_name.strip().title()}: "
+
                 def _add_prefix(val):
                     if pd.isna(val):
                         return prefix.strip()
                     return f"{prefix}{str(val).strip()}"
+
                 clean_df[ca_col] = clean_df[ca_col].apply(_add_prefix)
 
         return clean_df

--- a/tests/test_ar_center_cleaning.py
+++ b/tests/test_ar_center_cleaning.py
@@ -25,9 +25,9 @@ class TestARCenterCleaning(unittest.TestCase):
 
         cleaned = ExcelViewer._clean_dataframe(viewer, df, 'facility')
         self.assertIsNotNone(cleaned)
-        self.assertEqual(list(cleaned.columns), ['Sheet_Name', 'CAReportName', 'Val1'])
-        self.assertEqual(cleaned.iloc[0].tolist(), ['Facility', 'Facility: 0 - 30 days', 1.0])
-        self.assertEqual(cleaned.iloc[1].tolist(), ['Facility', 'Facility: 31 - 60 days', 2.0])
+        self.assertEqual(list(cleaned.columns), ['CAReportName', 'Val1'])
+        self.assertEqual(cleaned.iloc[0].tolist(), ['Facility: 0 - 30 days', 1.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ['Facility: 31 - 60 days', 2.0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- skip adding `Sheet_Name` column when cleaning AR Center reports
- prefix the first column with the sheet name if `CAReportName` is missing
- update AR Center cleaning test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686bd766e4408332b8a9b770268408c5