### PR TITLE
Correct AR Center prefix handling

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -446,10 +446,8 @@ class ResultsViewer(QWidget):
 
                     if (
                         report_type == "AR Center"
-                        and sheet_val
                         and self.results_data
                     ):
-                        prefix = f"{sheet_val.strip().title()}: "
                         first = self.results_data[0]
                         if isinstance(first, dict):
                             ca_col = None
@@ -462,7 +460,20 @@ class ResultsViewer(QWidget):
                                 ca_col = next(iter(first), None)
 
                             if ca_col:
+                                def _row_prefix(row):
+                                    name = None
+                                    if sheet_col and row.get(sheet_col):
+                                        name = row.get(sheet_col)
+                                    else:
+                                        name = sheet_val
+                                    if not name:
+                                        return ""
+                                    return f"{str(name).strip().title()}: "
+
                                 for row in self.results_data:
+                                    prefix = _row_prefix(row)
+                                    if not prefix:
+                                        continue
                                     val = row.get(ca_col)
                                     if pd.isna(val) or str(val).strip() == "":
                                         row[ca_col] = prefix.strip()

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -244,6 +244,41 @@ class ApplyCalculationsTest(unittest.TestCase):
         )
         self.assertTrue(has_prefixed_formula)
 
+    def test_apply_calculations_uses_row_sheet_prefix(self):
+        parent = self.MainWindow.__new__(self.MainWindow)
+        parent.config = DummyConfig()
+        parent.config.set_account_categories(
+            "AR Center",
+            {"Bad debt": ["Bad debt"]},
+        )
+        parent.config.set_account_formulas("AR Center", {"Bad debt percentage": "Bad debt"})
+        parent.config.report_type = "AR Center"
+        parent.comparison_engine = type("CE", (), {"sign_flip_accounts": []})()
+        parent.sheet_selector = DummySelector("facility")
+
+        viewer = self.ResultsViewer.__new__(self.ResultsViewer)
+        viewer.results_data = [
+            {"Sheet": "facility", "CAReportName": "Facility: Bad debt", "Amount": 100},
+            {"Sheet": "anesthesia", "CAReportName": "Anesthesia: Bad debt", "Amount": 50},
+        ]
+        viewer.columns = ["Sheet", "CAReportName", "Amount"]
+        viewer.table_view = DummyTable()
+        viewer.status_label = DummyLabel()
+        viewer.window = lambda: parent
+
+        viewer.apply_calculations()
+
+        fac_row = any(
+            row.get("CAReportName") == "Facility: Bad debt percentage" and row.get("Sheet") == "facility"
+            for row in viewer.results_data
+        )
+        ane_row = any(
+            row.get("CAReportName") == "Anesthesia: Bad debt percentage" and row.get("Sheet") == "anesthesia"
+            for row in viewer.results_data
+        )
+        self.assertTrue(fac_row)
+        self.assertTrue(ane_row)
+
 
 class SQLAccountExtractionTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- fix results_viewer to apply prefixes using each row's sheet
- test that calculations use per-row prefixes for AR Center sheets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d240e41d883329ff1b778921452a9