### PR TITLE
Fix sheet name selection in account categories dialog

### DIFF
--- a/src/ui/account_category_dialog.py
+++ b/src/ui/account_category_dialog.py
@@ -69,6 +69,9 @@ class AccountCategoryDialog(QDialog):
         existing_forms = config.config.get("account_formulas", {}).get(report_type, {})
 
         names = set(sheet_names or []) | set(existing_cats.keys()) | set(existing_forms.keys())
+        names = {n for n in names if n}
+        if config.DEFAULT_SHEET_NAME in names and len(names) > 1:
+            names.remove(config.DEFAULT_SHEET_NAME)
         if not names:
             names = {config.DEFAULT_SHEET_NAME}
         self.sheet_names = sorted(names)


### PR DESCRIPTION
## Summary
- clean up sheet list in `AccountCategoryDialog`
- drop blank and `__default__` sheet entries when real sheets are present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e7397b4108332a7628cad9ae6ae30