### PR TITLE
Add pivot option for detailed comparison

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1843,7 +1843,11 @@ class MainWindow(QMainWindow):
             # Generate detailed DataFrame
             report_type = self.config.get("excel", "report_type")
             df = self.comparison_engine.generate_detailed_comparison_dataframe(
-                sheet_name, excel_df, filtered_sql_df, report_type=report_type
+                sheet_name,
+                excel_df,
+                filtered_sql_df,
+                report_type=report_type,
+                pivot_results=True,
             )
             all_dfs.append(df)
         if not all_dfs:

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -85,3 +85,24 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
         self.assertIn('CAReport Name', df.columns)
         self.assertEqual(df['CAReport Name'].iloc[0], 'Acct A')
+
+    def test_pivot_results_single_row_per_record(self):
+        excel_df = pd.DataFrame({
+            'Center': [1, 2],
+            'CAReportName': ['Acct A', 'Acct B'],
+            'Amount': [100, 200],
+            'Quantity': [5, 10]
+        })
+        sql_df = pd.DataFrame({
+            'Center': [1, 2],
+            'CAReportName': ['Acct A', 'Acct B'],
+            'Amount': [100, 200],
+            'Quantity': [5, 10]
+        })
+        engine = ComparisonEngine()
+        df = engine.generate_detailed_comparison_dataframe(
+            'Sheet1', excel_df, sql_df, pivot_results=True
+        )
+        self.assertEqual(len(df), 2)
+        self.assertIn('Amount Excel', df.columns)
+        self.assertIn('Quantity Database', df.columns)


### PR DESCRIPTION
## Summary
- allow pivoting when generating detailed comparison results
- pass pivot option when exporting results
- verify pivot option via new test

## Testing
- `pytest tests/test_comparison_engine.py::TestComparisonEngineSignFlip::test_pivot_results_single_row_per_record -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ee25fda2083328064df72483721ea