### PR TITLE
Fix export crash from missing key columns

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -325,27 +325,40 @@ class ComparisonEngine:
     def _identify_key_columns(self, excel_df, sql_df, column_mappings):
         """Identify key columns for joining Excel and SQL data"""
         # First try to find Center and CAReportName columns
-        key_columns = {
-            'excel': [],
-            'sql': []
+        key_columns = {"excel": [], "sql": []}
+
+        def _norm(name: str) -> str:
+            return re.sub(r"[\s_]+", "", str(name)).lower()
+
+        center_synonyms = {
+            "center",
+            "centernumber",
+            "center number",
+            "facility",
+            "facilitynumber",
+            "facility number",
         }
-        
-        # Look for Center column
+        acct_synonyms = {
+            "careportname",
+            "account",
+            "accountnumber",
+            "account number",
+            "acct",
+        }
+
         for mapping in column_mappings.values():
-            if mapping['excel_column'].lower() == 'center':
-                key_columns['excel'].append(mapping['excel_column'])
-                key_columns['sql'].append(mapping['sql_column'])
+            if _norm(mapping["excel_column"]) in center_synonyms:
+                key_columns["excel"].append(mapping["excel_column"])
+                key_columns["sql"].append(mapping["sql_column"])
                 break
-        
-        # Look for CAReportName column
+
         for mapping in column_mappings.values():
-            if mapping['excel_column'].lower() == 'careportname':
-                key_columns['excel'].append(mapping['excel_column'])
-                key_columns['sql'].append(mapping['sql_column'])
+            if _norm(mapping["excel_column"]) in acct_synonyms:
+                key_columns["excel"].append(mapping["excel_column"])
+                key_columns["sql"].append(mapping["sql_column"])
                 break
-        
-        # If we found both key columns, return them
-        if len(key_columns['excel']) == 2:
+
+        if key_columns["excel"]:
             return key_columns
         
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1842,12 +1842,16 @@ class MainWindow(QMainWindow):
 
             # Generate detailed DataFrame
             report_type = self.config.get("excel", "report_type")
-            df = self.comparison_engine.generate_detailed_comparison_dataframe(
-                sheet_name,
-                excel_df,
-                filtered_sql_df,
-                report_type=report_type,
-            )
+            try:
+                df = self.comparison_engine.generate_detailed_comparison_dataframe(
+                    sheet_name,
+                    excel_df,
+                    filtered_sql_df,
+                    report_type=report_type,
+                )
+            except ValueError as e:
+                QMessageBox.critical(self, "Export Error", str(e))
+                return
             all_dfs.append(df)
         if not all_dfs:
             QMessageBox.warning(self, "No Data", "No detailed results to export.")
@@ -1966,9 +1970,13 @@ class MainWindow(QMainWindow):
                     filtered_sql_df = pd.DataFrame(calc.compute(sql_rows))
 
             report_type = self.config.get("excel", "report_type")
-            df = self.comparison_engine.generate_detailed_comparison_dataframe(
-                sheet_name, excel_df, filtered_sql_df, report_type=report_type
-            )
+            try:
+                df = self.comparison_engine.generate_detailed_comparison_dataframe(
+                    sheet_name, excel_df, filtered_sql_df, report_type=report_type
+                )
+            except ValueError as e:
+                QMessageBox.critical(self, "Export Error", str(e))
+                return
             all_dfs.append(df)
         if not all_dfs:
             QMessageBox.warning(self, "No Data", "No detailed results to export.")
@@ -2065,9 +2073,13 @@ class MainWindow(QMainWindow):
                     filtered_sql_df = pd.DataFrame(calc.compute(sql_rows))
 
             report_type = self.config.get("excel", "report_type")
-            df = self.comparison_engine.generate_detailed_comparison_dataframe(
-                sheet_name, excel_df, filtered_sql_df, report_type=report_type
-            )
+            try:
+                df = self.comparison_engine.generate_detailed_comparison_dataframe(
+                    sheet_name, excel_df, filtered_sql_df, report_type=report_type
+                )
+            except ValueError as e:
+                QMessageBox.critical(self, "Export Error", str(e))
+                return
             all_dfs.append(df)
         if not all_dfs:
             QMessageBox.warning(self, "No Data", "No detailed results to export.")

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -105,3 +105,18 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         self.assertEqual(len(df), 2)
         self.assertIn('Amount Excel', df.columns)
         self.assertIn('Quantity Database', df.columns)
+
+    def test_key_column_synonyms(self):
+        excel_df = pd.DataFrame({
+            'Facility': [1],
+            'Account': ['1234-5678'],
+            'Amount': [100]
+        })
+        sql_df = pd.DataFrame({
+            'Facility Number': [1],
+            'Account Number': ['1234-5678'],
+            'Amount': [100]
+        })
+        engine = ComparisonEngine()
+        df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
+        self.assertTrue((df['Result'] == 'Match').all())


### PR DESCRIPTION
## Summary
- improve key column detection with common synonyms
- catch `ValueError` during export routines so the GUI doesn't crash
- add regression test covering synonym handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68712f7ef65083328f7adf4c0c79ee01