### PR TITLE
Improve key column detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ If you're experiencing issues with temp tables, try:
 - Adding semicolons between statements
 - Using the specialized scripts in the `src/analyzer/` directory
 
+### Key Column Detection
+
+The comparison engine looks for common keywords when trying to identify the
+"Center" and "Account" columns. After normalizing column names, any name
+containing the following keywords will be treated as a potential match:
+
+- **Center keywords:** `center`, `facility`, `department`, `dept`
+- **Account keywords:** `account`, `careport`, `acct`
+
+If your export uses different wording, ensure that one of these keywords is
+present so the automatic matching succeeds.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -345,20 +345,55 @@ class ComparisonEngine:
             "account number",
             "acct",
         }
+        center_keywords = [
+            "center",
+            "facility",
+            "department",
+            "dept",
+        ]
+        acct_keywords = [
+            "account",
+            "careport",
+            "acct",
+        ]
+
+        center_found = False
+        acct_found = False
 
         for mapping in column_mappings.values():
             if _norm(mapping["excel_column"]) in center_synonyms:
                 key_columns["excel"].append(mapping["excel_column"])
                 key_columns["sql"].append(mapping["sql_column"])
+                center_found = True
                 break
 
         for mapping in column_mappings.values():
             if _norm(mapping["excel_column"]) in acct_synonyms:
                 key_columns["excel"].append(mapping["excel_column"])
                 key_columns["sql"].append(mapping["sql_column"])
+                acct_found = True
                 break
 
-        if key_columns["excel"]:
+        # Fallback: check for keywords contained in the normalized names
+        if not center_found:
+            for mapping in column_mappings.values():
+                norm = _norm(mapping["excel_column"])
+                if any(kw in norm for kw in center_keywords):
+                    key_columns["excel"].append(mapping["excel_column"])
+                    key_columns["sql"].append(mapping["sql_column"])
+                    center_found = True
+                    break
+
+        if not acct_found:
+            for mapping in column_mappings.values():
+                norm = _norm(mapping["excel_column"])
+                if any(kw in norm for kw in acct_keywords):
+                    key_columns["excel"].append(mapping["excel_column"])
+                    key_columns["sql"].append(mapping["sql_column"])
+                    acct_found = True
+                    break
+
+        if center_found or acct_found:
             return key_columns
         
 

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -120,3 +120,18 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         engine = ComparisonEngine()
         df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
         self.assertTrue((df['Result'] == 'Match').all())
+
+    def test_key_column_keyword_detection(self):
+        excel_df = pd.DataFrame({
+            'My Facility ID': [1],
+            'Acct - Desc': ['1234-5678'],
+            'Amount': [100]
+        })
+        sql_df = pd.DataFrame({
+            'Center_ID': [1],
+            'Account Number': ['1234-5678'],
+            'Amount': [100]
+        })
+        engine = ComparisonEngine()
+        df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
+        self.assertTrue((df['Result'] == 'Match').all())


### PR DESCRIPTION
## Summary
- enhance `_identify_key_columns` with keyword-based detection
- update comparison tests for keyword detection
- document recognized keywords in troubleshooting section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6871617a69a88332ae0895bcab74a07b