### PR TITLE
Fix join key side effect

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -166,7 +166,9 @@ class ComparisonEngine:
             "sql": sql_dup_keys.value_counts().to_dict() if not sql_dup_keys.empty else {}
         }
         
-        # Add keys to dataframes
+        # Add keys to dataframes without mutating the originals
+        excel_df = excel_df.copy()
+        sql_df = sql_df.copy()
         excel_df['_join_key'] = excel_keys
         sql_df['_join_key'] = sql_keys
         


### PR DESCRIPTION
## Summary
- ensure ComparisonEngine.copy_dataframes when adding join key columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687670c2032883328db85871ac8ea539