### PR TITLE
Improve comparison engine validation and tests

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -567,6 +567,21 @@ class ComparisonEngine:
         key_columns = self._identify_key_columns(excel_df, sql_df, column_mappings)
         if not key_columns:
             raise ValueError("Could not identify key columns for joining")
+
+        # Validate input DataFrames before building join keys
+        if excel_df.empty or sql_df.empty:
+            self.logger.warning("One or both dataframes are empty")
+            raise ValueError("One or both dataframes are empty")
+
+        missing_excel = [col for col in key_columns['excel'] if col not in excel_df.columns]
+        missing_sql = [col for col in key_columns['sql'] if col not in sql_df.columns]
+        if missing_excel or missing_sql:
+            self.logger.warning(
+                "Key columns missing from dataframes. Excel missing: %s; SQL missing: %s",
+                missing_excel,
+                missing_sql,
+            )
+            raise ValueError("Key columns missing from dataframes")
         
         # Prepare sign flip accounts as a set of stripped strings
         sign_flip_accounts_str = set(str(acct).strip() for acct in getattr(self, 'sign_flip_accounts', set()))

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1860,7 +1860,7 @@ class MainWindow(QMainWindow):
                     report_type=report_type,
                 )
             except ValueError as e:
-                QMessageBox.critical(self, "Export Error", str(e))
+                QMessageBox.critical(self, "Export Error", f"Failed to generate detailed results: {str(e)}")
                 return
             all_dfs.append(df)
         if not all_dfs:
@@ -1989,7 +1989,7 @@ class MainWindow(QMainWindow):
                     report_type=report_type,
                 )
             except ValueError as e:
-                QMessageBox.critical(self, "Export Error", str(e))
+                QMessageBox.critical(self, "Export Error", f"Failed to generate detailed results: {str(e)}")
                 return
             all_dfs.append(df)
         if not all_dfs:
@@ -2096,7 +2096,7 @@ class MainWindow(QMainWindow):
                     report_type=report_type,
                 )
             except ValueError as e:
-                QMessageBox.critical(self, "Export Error", str(e))
+                QMessageBox.critical(self, "Export Error", f"Failed to generate detailed results: {str(e)}")
                 return
             all_dfs.append(df)
         if not all_dfs:

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -135,3 +135,23 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         engine = ComparisonEngine()
         df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
         self.assertTrue((df['Result'] == 'Match').all())
+
+    def test_empty_sql_dataframe_raises(self):
+        empty_sql = pd.DataFrame(columns=self.sql_df.columns)
+        with self.assertRaises(ValueError):
+            self.engine.generate_detailed_comparison_dataframe(
+                'Sheet1', self.excel_df, empty_sql
+            )
+
+    def test_missing_key_columns_raise(self):
+        excel_df = pd.DataFrame({'Amount': [100]})
+        sql_df = pd.DataFrame({'Amount': [100]})
+        column_mappings = {
+            0: {'excel_column': 'Center', 'sql_column': 'Center', 'match_score': 1.0},
+            1: {'excel_column': 'CAReportName', 'sql_column': 'CAReportName', 'match_score': 1.0},
+            2: {'excel_column': 'Amount', 'sql_column': 'Amount', 'match_score': 1.0},
+        }
+        with self.assertRaises(ValueError):
+            self.engine.generate_detailed_comparison_dataframe(
+                'Sheet1', excel_df, sql_df, column_mappings=column_mappings
+            )


### PR DESCRIPTION
## Summary
- raise ValueError when either dataframe is empty in `generate_detailed_comparison_dataframe`
- validate presence of key columns when generating detailed results
- show an error dialog if detailed results fail to generate during export
- add tests for empty dataframes and missing key columns

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876853caa308332999de71a93eb5031