### PR TITLE
Handle empty DataFrames in comparison

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -571,7 +571,7 @@ class ComparisonEngine:
         # Validate input DataFrames before building join keys
         if excel_df.empty or sql_df.empty:
             self.logger.warning("One or both dataframes are empty")
-            raise ValueError("One or both dataframes are empty")
+            return pd.DataFrame()
 
         missing_excel = [col for col in key_columns['excel'] if col not in excel_df.columns]
         missing_sql = [col for col in key_columns['sql'] if col not in sql_df.columns]

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -136,12 +136,12 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
         df = engine.generate_detailed_comparison_dataframe('Sheet1', excel_df, sql_df)
         self.assertTrue((df['Result'] == 'Match').all())
 
-    def test_empty_sql_dataframe_raises(self):
+    def test_empty_sql_dataframe_returns_empty(self):
         empty_sql = pd.DataFrame(columns=self.sql_df.columns)
-        with self.assertRaises(ValueError):
-            self.engine.generate_detailed_comparison_dataframe(
-                'Sheet1', self.excel_df, empty_sql
-            )
+        df = self.engine.generate_detailed_comparison_dataframe(
+            'Sheet1', self.excel_df, empty_sql
+        )
+        self.assertTrue(df.empty)
 
     def test_missing_key_columns_raise(self):
         excel_df = pd.DataFrame({'Amount': [100]})


### PR DESCRIPTION
## Summary
- avoid raising an exception in `generate_detailed_comparison_dataframe` when either input dataframe is empty
- adjust comparison engine tests to reflect new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68768f1867a08332b8b5411fa76c5831