### PR TITLE
Fix sheet names and include mismatch field

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -617,7 +617,9 @@ class ComparisonEngine:
         account_col_excel, account_col_sql = self._find_account_columns(merged_df.columns)
         
         include_center = report_type not in ("SOO MFR", "Corp SOO")
-        include_sheet = report_type not in ("SOO MFR", "Corp SOO")
+        # Always include the sheet name so exports contain a reference to
+        # which tab the result came from.
+        include_sheet = True
 
         output_rows = []
         for excel_idx, mapping in column_mappings.items():
@@ -636,7 +638,9 @@ class ComparisonEngine:
                     or (row.get(account_col_sql) if account_col_sql else None)
                     or ''
                 )
-                field = excel_col
+                # Report the SQL column name in the output so mismatches show
+                # which field in the database caused the difference.
+                field = sql_col
                 excel_val = row.get(excel_merged_col, None)
                 sql_val = row.get(sql_merged_col, None)
                 # Get account value for sign flip

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1875,14 +1875,16 @@ class MainWindow(QMainWindow):
         combined_df = combined_df.rename(
             columns={k: v for k, v in rename_map.items() if k in combined_df.columns}
         )
+        # Keep the field information so users can identify which database column
+        # was compared. Drop the Center column instead.
         combined_df = combined_df.drop(
-            columns=[c for c in ["Field", "Issue"] if c in combined_df.columns]
+            columns=[c for c in ["Center", "Issue"] if c in combined_df.columns]
         )
         ordered_cols = [
             c
             for c in [
                 "Sheet",
-                "Center",
+                "Field",
                 "CAReportName",
                 "Excel Value",
                 "DB Value",


### PR DESCRIPTION
## Summary
- always include sheet name when generating detailed comparison data
- keep mismatching field info and drop center column when exporting to Excel
- report SQL column name for each compared field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876bd2bcdc08332a1598117cc7f3efd