### PR TITLE
Improve sheet column detection

### DIFF
--- a/tests/test_gather_sheet_names_sql.py
+++ b/tests/test_gather_sheet_names_sql.py
@@ -25,16 +25,11 @@ class TestGatherSheetNamesSQL(unittest.TestCase):
         window.logger = types.SimpleNamespace(error=lambda *a, **k: None)
         return window._gather_sheet_names_from_sql()
 
-    def test_lowercase_column_names(self):
-        for cand in ["sheet_name", "sheet", "sheetname"]:
+    def test_various_column_names(self):
+        for cand in ["sheet_name", "sheet", "sheetname", "SheetName", "Sheet Name"]:
             df = pd.DataFrame({cand: ["Foo", "Bar", "Foo"], "Amount": [1, 2, 3]})
             sheets = self._gather(df)
             self.assertEqual(sheets, ["Bar", "Foo"])
-
-    def test_space_in_column_name(self):
-        df = pd.DataFrame({"Sheet Name": ["One", "Two", "One"], "Val": [1, 2, 3]})
-        sheets = self._gather(df)
-        self.assertEqual(sheets, ["One", "Two"])
 
     def test_from_careportname_prefix(self):
         df = pd.DataFrame(


### PR DESCRIPTION
## Summary
- extract sheet column name detection into new helper `_detect_sheet_column`
- reuse helper when gathering sheet names from SQL
- update comparison and export routines to use the new detection logic
- broaden sheet name unit tests to cover more column variants

## Testing
- `pytest tests/test_gather_sheet_names_sql.py::TestGatherSheetNamesSQL::test_various_column_names -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876c7dc323c8332a64b79885a265737