### PR TITLE
Fix image path in report

### DIFF
--- a/src/reporting/temp_report.html
+++ b/src/reporting/temp_report.html
@@ -133,7 +133,7 @@
         </div>
         
         <div class="chart-container">
-            <img src="C:\Users\JoRitchie\Desktop\Cognos QA\ReportTestingApplication\reporttestingapp\reporttestingapp\src\reporting\match_pie_chart.png" class="chart" alt="Match Distribution">
+            <img src="match_pie_chart.png" class="chart" alt="Match Distribution">
         </div>
         
         <div class="table-container">


### PR DESCRIPTION
## Summary
- use relative path for the chart in `temp_report.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876cd32d2808332890a87e85babf10f