### PR TITLE
Update AR Center sheet handling

### DIFF
--- a/src/analyzer/comparison_engine.py
+++ b/src/analyzer/comparison_engine.py
@@ -339,6 +339,8 @@ class ComparisonEngine:
             "facility",
             "facilitynumber",
             "facility number",
+            "sheet",
+            "sheetname",
         }
         acct_synonyms = {
             "careportname",
@@ -352,6 +354,7 @@ class ComparisonEngine:
             "facility",
             "department",
             "dept",
+            "sheet",
         ]
         acct_keywords = [
             "account",

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -897,34 +897,9 @@ class MainWindow(QMainWindow):
                             ]
                     # If no key columns, fallback to all rows (legacy behavior)
 
-                    # When comparing AR Center reports, the Excel side prefixes
-                    # account names with the sheet name during cleaning. Apply
-                    # the same prefix to the SQL dataframe so the values align.
+                    # AR Center comparisons now rely on an explicit ``Sheet``
+                    # column rather than prefixing ``CAReportName`` values.
                     report_type = self.report_selector.currentText()
-                    if report_type == "AR Center" and not filtered_sql_df.empty:
-                        ca_col = None
-                        for col in filtered_sql_df.columns:
-                            normalized = str(col).strip().replace(" ", "").lower()
-                            if normalized == "careportname":
-                                ca_col = col
-                                break
-                        if ca_col is None:
-                            ca_col = filtered_sql_df.columns[0]
-                        prefix = f"{sheet_name.title()}: "
-
-                        def _add_prefix(val):
-                            if pd.isna(val):
-                                return prefix.strip()
-                            val_str = str(val).strip()
-                            return (
-                                val_str
-                                if val_str.lower().startswith(prefix.strip().lower())
-                                else f"{prefix}{val_str}"
-                            )
-
-                        filtered_sql_df[ca_col] = filtered_sql_df[ca_col].apply(
-                            _add_prefix
-                        )
 
                     # Perform comparison
                     sheet_result = self.comparison_engine.compare_dataframes(

--- a/tests/test_gather_sheet_names_sql.py
+++ b/tests/test_gather_sheet_names_sql.py
@@ -31,14 +31,11 @@ class TestGatherSheetNamesSQL(unittest.TestCase):
             sheets = self._gather(df)
             self.assertEqual(sheets, ["Bar", "Foo"])
 
-    def test_from_careportname_prefix(self):
+    def test_from_sheet_column(self):
         df = pd.DataFrame(
             {
-                "CAReportName": [
-                    "Facility: 0 - 30 days",
-                    "Corporate: 31 - 60",
-                    "Facility: 90+",
-                ],
+                "Sheet": ["Facility", "Corporate", "Facility"],
+                "CAReportName": ["0 - 30 days", "31 - 60", "90+"],
                 "Amount": [1, 2, 3],
             }
         )

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -454,7 +454,7 @@ class ARCenterResultsLoadTest(unittest.TestCase):
         viewer = self._load(data, ["Sheet", "CAReportName"], sheet="facility")
         self.assertEqual(
             [row["CAReportName"] for row in viewer.results_data],
-            ["Facility: 0 - 30 days", "Anesthesia: Bad debt"],
+            ["0 - 30 days", "Bad debt"],
         )
 
 


### PR DESCRIPTION
## Summary
- add a Sheet column for AR Center during cleaning
- drop CAReportName prefixing and rely on sheet column for comparisons
- adjust comparison engine to treat sheet name as a key column
- remove SQL prefix logic from result loading and comparison
- update unit tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6877ac802df88332be7283e3a71ff13e