### PR TITLE
Fix sheet name duplication in calculations

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -442,45 +442,10 @@ class ResultsViewer(QWidget):
                         include_categories=False,
                     )
 
-                    if report_type == "AR Center" and self.results_data:
-                        first = self.results_data[0]
-                        if isinstance(first, dict):
-                            ca_col = None
-                            for col in first:
-                                normalized = str(col).strip().replace(" ", "").lower()
-                                if normalized == "careportname":
-                                    ca_col = col
-                                    break
-                            if ca_col is None:
-                                ca_col = next(iter(first), None)
 
-                            if ca_col:
-
-                                def _row_prefix(row):
-                                    name = None
-                                    if sheet_col and row.get(sheet_col):
-                                        name = row.get(sheet_col)
-                                    else:
-                                        name = sheet_val
-                                    if not name:
-                                        return ""
-                                    return f"{str(name).strip().title()}: "
-
-                                for row in self.results_data:
-                                    prefix = _row_prefix(row)
-                                    if not prefix:
-                                        continue
-                                    val = row.get(ca_col)
-                                    if pd.isna(val) or str(val).strip() == "":
-                                        row[ca_col] = prefix.strip()
-                                    else:
-                                        val_str = str(val).strip()
-                                        if not val_str.lower().startswith(
-                                            prefix.strip().lower()
-                                        ):
-                                            row[ca_col] = f"{prefix}{val_str}"
-                                        else:
-                                            row[ca_col] = val_str
+                    # Do not prefix account names with the sheet name. The sheet
+                    # column is already present in the data and can be used
+                    # directly for any grouping logic.
 
         # Refresh the table model with new rows
         self.model = ResultsTableModel(self.results_data, self.columns)

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -241,7 +241,7 @@ class ApplyCalculationsTest(unittest.TestCase):
         self.assertNotIn("Sheet", viewer.columns)
         self.assertIn("SheetName", viewer.columns)
 
-    def test_apply_calculations_prefixes_formula_rows(self):
+    def test_apply_calculations_formula_rows_unprefixed(self):
         parent = self.MainWindow.__new__(self.MainWindow)
         parent.config = DummyConfig()
         parent.config.set_account_categories(
@@ -266,13 +266,14 @@ class ApplyCalculationsTest(unittest.TestCase):
 
         viewer.apply_calculations()
 
-        has_prefixed_formula = any(
-            row.get("CAReportName") == "Facility: Bad debt percentage"
+        # Formula rows should not be prefixed with the sheet name
+        has_formula = any(
+            row.get("CAReportName") == "Bad debt percentage"
             for row in viewer.results_data
         )
-        self.assertTrue(has_prefixed_formula)
+        self.assertTrue(has_formula)
 
-    def test_apply_calculations_uses_row_sheet_prefix(self):
+    def test_apply_calculations_respects_row_sheet(self):
         parent = self.MainWindow.__new__(self.MainWindow)
         parent.config = DummyConfig()
         parent.config.set_account_categories(
@@ -303,13 +304,11 @@ class ApplyCalculationsTest(unittest.TestCase):
         viewer.apply_calculations()
 
         fac_row = any(
-            row.get("CAReportName") == "Facility: Bad debt percentage"
-            and row.get("Sheet") == "facility"
+            row.get("CAReportName") == "Bad debt percentage" and row.get("Sheet") == "facility"
             for row in viewer.results_data
         )
         ane_row = any(
-            row.get("CAReportName") == "Anesthesia: Bad debt percentage"
-            and row.get("Sheet") == "anesthesia"
+            row.get("CAReportName") == "Bad debt percentage" and row.get("Sheet") == "anesthesia"
             for row in viewer.results_data
         )
         self.assertTrue(fac_row)


### PR DESCRIPTION
## Summary
- stop prefixing CAReportName with the sheet
- update tests to expect unprefixed formula rows

## Testing
- `pytest -q` *(fails: Could not find pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6877b0ec77a48332a54661589c55a53d