### PR TITLE
Add formula library support

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1809,7 +1809,12 @@ class MainWindow(QMainWindow):
             report_type = self.config.get("excel", "report_type")
             if report_type:
                 categories = self.config.get_account_categories(report_type)
-                formulas = self.config.get_account_formulas(report_type)
+                lib = self.config.get_formula_library()
+                formulas = {
+                    n: info
+                    for n, info in lib.items()
+                    if not info.get("sheets") or sheet_name in info.get("sheets")
+                }
                 if categories:
                     group_col = None
                     cols_lower = {c.lower(): c for c in filtered_sql_df.columns}
@@ -1957,7 +1962,12 @@ class MainWindow(QMainWindow):
             report_type = self.config.get("excel", "report_type")
             if report_type:
                 categories = self.config.get_account_categories(report_type)
-                formulas = self.config.get_account_formulas(report_type)
+                lib = self.config.get_formula_library()
+                formulas = {
+                    n: info
+                    for n, info in lib.items()
+                    if not info.get("sheets") or sheet_name in info.get("sheets")
+                }
                 if categories:
                     group_col = None
                     cols_lower = {c.lower(): c for c in filtered_sql_df.columns}
@@ -2081,7 +2091,12 @@ class MainWindow(QMainWindow):
             report_type = self.config.get("excel", "report_type")
             if report_type:
                 categories = self.config.get_account_categories(report_type)
-                formulas = self.config.get_account_formulas(report_type)
+                lib = self.config.get_formula_library()
+                formulas = {
+                    n: info
+                    for n, info in lib.items()
+                    if not info.get("sheets") or sheet_name in info.get("sheets")
+                }
                 if categories:
                     group_col = None
                     cols_lower = {c.lower(): c for c in filtered_sql_df.columns}

--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -379,7 +379,12 @@ class ResultsViewer(QWidget):
             report_type = parent.config.get("excel", "report_type")
             if report_type:
                 categories = parent.config.get_account_categories(report_type)
-                formulas = parent.config.get_account_formulas(report_type)
+                lib = parent.config.get_formula_library()
+                formulas = {
+                    n: info
+                    for n, info in lib.items()
+                    if not info.get("sheets") or sheet_val in info.get("sheets")
+                }
                 if categories:
                     sheet_col = None
                     sheet_val = ""


### PR DESCRIPTION
## Summary
- expand `AppConfig` with global formula library
- handle `display_name` in `CategoryCalculator`
- support formulas across sheets in main window and results viewer
- update account category dialog to edit formulas in library
- migrate old formula config to new structure
- adjust tests for formula library

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6877bb68793083329405504580795f9d