### PR TITLE
Remove unused header_has_values variable

### DIFF
--- a/src/ui/excel_viewer.py
+++ b/src/ui/excel_viewer.py
@@ -1032,12 +1032,6 @@ class ExcelViewer(QWidget):
                 row = row.ffill()
                 header_rows.append(row)
 
-            # Check if there are any non-empty values in the header rows
-            header_has_values = []
-            for row in header_rows:
-                has_values = sum(1 for x in row if pd.notna(x) and str(x).strip()) > 0
-                header_has_values.append(has_values)
-
             # Create a copy of the data portion of the dataframe (after headers)
             data_df = df.iloc[skip_rows:].copy()
 


### PR DESCRIPTION
## Summary
- clean up `_base_clean_dataframe` by removing `header_has_values` logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687f9a2e03e88332aac82a412c6c62c3