### PR TITLE
Add database credential parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,20 @@ A high-quality application for testing Excel reports against SQL databases, espe
 
 1. Clone this repository
 2. Install the project into your environment:
-   ```
-   pip install .
-   ```
+ ```
+  pip install .
+  ```
 3. Configure your database settings in the application
+
+### Database Settings
+
+The `DatabaseConnector` class accepts the following parameters:
+
+- `server` – SQL Server hostname
+- `database` – default database name
+- `trusted_connection` – set to `False` to use SQL authentication
+- `uid` – SQL username when `trusted_connection` is `False`
+- `pwd` – SQL password when `trusted_connection` is `False`
 
 ### Using the Executable
 


### PR DESCRIPTION
## Summary
- support uid/pwd in `DatabaseConnector`
- document the additional parameters in the README

## Testing
- `pytest -q tests/test_db_connector.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install SQLAlchemy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f9b4344b8833290ec2c082ee79b8d