### PR TITLE
Unified reporting module

### DIFF
--- a/src/analyzer/api.py
+++ b/src/analyzer/api.py
@@ -12,9 +12,11 @@ def compare_and_report(sheet_name: str, excel_df: pd.DataFrame, sql_df: pd.DataF
     engine.set_tolerance(tolerance)
     engine.set_sign_flip_accounts(sign_flip_accounts)
     results = engine.compare_dataframes(excel_df, sql_df)
+    mismatches = engine.generate_detailed_comparison_dataframe(sheet_name, excel_df, sql_df)
     report = generate_report(
         sheet_name,
         results,
+        mismatches,
         sign_flip_accounts,
         results.get("suggested_sign_flips"),
     )

--- a/tests/test_comparison_engine.py
+++ b/tests/test_comparison_engine.py
@@ -155,3 +155,12 @@ class TestComparisonEngineSignFlip(unittest.TestCase):
             self.engine.generate_detailed_comparison_dataframe(
                 'Sheet1', excel_df, sql_df, column_mappings=column_mappings
             )
+
+    def test_generate_comparison_report_content(self):
+        self.engine.set_sign_flip_accounts(['1234-5678'])
+        results = self.engine.compare_dataframes(self.excel_df, self.sql_df)
+        df = self.engine.generate_detailed_comparison_dataframe('Sheet1', self.excel_df, self.sql_df)
+        report = self.engine.generate_comparison_report('Sheet1', results, mismatches_df=df)
+        self.assertIn('PERFECT MATCH', report)
+        self.assertIn('Per-Column Mismatches', report)
+        self.assertIn('## Mismatches', report)

--- a/tests/test_helper_modules.py
+++ b/tests/test_helper_modules.py
@@ -37,9 +37,17 @@ class TestHelperModules(unittest.TestCase):
     def test_report_generator(self):
         comparison_results = {
             'summary': {'mismatch_percentage': 0, 'matching_cells': 3, 'total_cells': 3},
-            'row_counts': {'excel': 2, 'sql': 2, 'matched': 2}
+            'row_counts': {'excel': 2, 'sql': 2, 'matched': 2},
+            'column_comparisons': {'Amount': {'mismatch_count': 0}},
         }
-        report = report_generator.generate_report('Sheet1', comparison_results, ['1234-5678'], ['1111-2222'])
+        df = pd.DataFrame({'Result': ['Match']})
+        report = report_generator.generate_report(
+            'Sheet1',
+            comparison_results,
+            df,
+            ['1234-5678'],
+            ['1111-2222']
+        )
         self.assertIn('PERFECT MATCH', report)
         self.assertIn('Sign Flip Accounts Applied', report)
         self.assertIn('Suggested Sign Flip Accounts', report)


### PR DESCRIPTION
## Summary
- consolidate reporting logic into `report_generator`
- expose HTML/Markdown output
- store last dataframes for reporting
- update ComparisonEngine and API helpers
- validate new report content in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687fcd37fc008332ac85b3088b549f94