### PR TITLE
Improve duplicate row detection

### DIFF
--- a/tests/test_corp_soo_cleaning.py
+++ b/tests/test_corp_soo_cleaning.py
@@ -2,86 +2,107 @@ import unittest
 import pandas as pd
 from tests.qt_stubs import patch_qt_modules
 
+
 class TestCorpSOOCleaning(unittest.TestCase):
     def setUp(self):
         patch_qt_modules()
 
     def test_corp_soo_clean(self):
         from src.ui.excel_viewer import ExcelViewer
+
         viewer = ExcelViewer.__new__(ExcelViewer)
         viewer.report_config = {
-            'header_rows': [0],
-            'skip_rows': 1,
-            'first_data_column': 2,
-            'description': ''
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 2,
+            "description": "",
         }
-        viewer.report_type = 'Corp SOO'
+        viewer.report_type = "Corp SOO"
 
-        df = pd.DataFrame([
-            ['A','B','C'],
-            ['acct1','', ''],
-            ['acct2',1,2],
-            ['acct2',0,'foo'],
-            ['', '', ''],
-            ['acct3',0,0]
-        ])
+        df = pd.DataFrame(
+            [
+                ["A", "B", "C"],
+                ["acct1", "", ""],
+                ["acct2", 1, 2],
+                ["acct2", 0, "foo"],
+                ["", "", ""],
+                ["acct3", 0, 0],
+            ]
+        )
 
-        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "Sheet1")
         self.assertIsNotNone(cleaned)
-        self.assertEqual(list(cleaned.columns), ['A','B','C'])
+        self.assertEqual(list(cleaned.columns), ["A", "B", "C"])
         self.assertEqual(len(cleaned), 3)
-        self.assertEqual(cleaned.iloc[0].tolist(), ['acct2', 1.0, 2.0])
-        self.assertEqual(cleaned.iloc[1].tolist(), ['acct2', 0, 'foo'])
-        self.assertEqual(cleaned.iloc[2].tolist(), ['acct3', 0, 0.0])
+        self.assertEqual(cleaned.iloc[0].tolist(), ["acct2", 1.0, 2.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ["acct2", 0, "foo"])
+        self.assertEqual(cleaned.iloc[2].tolist(), ["acct3", 0, 0.0])
 
     def test_text_column_not_dropped(self):
         """Purely textual columns should be preserved when cleaning."""
         from src.ui.excel_viewer import ExcelViewer
+
         viewer = ExcelViewer.__new__(ExcelViewer)
         viewer.report_config = {
-            'header_rows': [0],
-            'skip_rows': 1,
-            'first_data_column': 2,
-            'description': ''
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 2,
+            "description": "",
         }
-        viewer.report_type = 'Corp SOO'
+        viewer.report_type = "Corp SOO"
 
-        df = pd.DataFrame([
-            ['CAReportName', 'Val1', 'Val2'],
-            ['TextA', 0, 0],
-            ['TextB', 1, 2]
-        ])
+        df = pd.DataFrame(
+            [["CAReportName", "Val1", "Val2"], ["TextA", 0, 0], ["TextB", 1, 2]]
+        )
 
-        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "Sheet1")
         self.assertIsNotNone(cleaned)
-        self.assertEqual(list(cleaned.columns), ['CAReportName', 'Val1', 'Val2'])
+        self.assertEqual(list(cleaned.columns), ["CAReportName", "Val1", "Val2"])
         self.assertEqual(len(cleaned), 2)
-        self.assertEqual(cleaned.iloc[0].tolist(), ['TextA', 0, 0.0])
-        self.assertEqual(cleaned.iloc[1].tolist(), ['TextB', 1, 2.0])
+        self.assertEqual(cleaned.iloc[0].tolist(), ["TextA", 0, 0.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ["TextB", 1, 2.0])
 
     def test_zero_numeric_rows_preserved(self):
         """Rows with text in the first column and zero numeric values remain."""
         from src.ui.excel_viewer import ExcelViewer
+
         viewer = ExcelViewer.__new__(ExcelViewer)
         viewer.report_config = {
-            'header_rows': [0],
-            'skip_rows': 1,
-            'first_data_column': 2,
-            'description': ''
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 2,
+            "description": "",
         }
-        viewer.report_type = 'Corp SOO'
+        viewer.report_type = "Corp SOO"
 
-        df = pd.DataFrame([
-            ['A', 'B', 'C'],
-            ['RowZero', 0, 0],
-            ['RowData', 1, 2]
-        ])
+        df = pd.DataFrame([["A", "B", "C"], ["RowZero", 0, 0], ["RowData", 1, 2]])
 
-        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "Sheet1")
         self.assertIsNotNone(cleaned)
         self.assertEqual(len(cleaned), 2)
-        self.assertEqual(cleaned.iloc[0].tolist(), ['RowZero', 0, 0.0])
-        self.assertEqual(cleaned.iloc[1].tolist(), ['RowData', 1, 2.0])
+        self.assertEqual(cleaned.iloc[0].tolist(), ["RowZero", 0, 0.0])
+        self.assertEqual(cleaned.iloc[1].tolist(), ["RowData", 1, 2.0])
 
-if __name__ == '__main__':
+    def test_zero_numeric_rows_blank_first_column_removed(self):
+        """Rows with blank first column and zeros should be dropped."""
+        from src.ui.excel_viewer import ExcelViewer
+
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_config = {
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 2,
+            "description": "",
+        }
+        viewer.report_type = "Corp SOO"
+
+        df = pd.DataFrame([["A", "B", "C"], ["", 0, 0], ["RowData", 1, 2]])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "Sheet1")
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(cleaned.iloc[0].tolist(), ["RowData", 1, 2.0])
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_remove_duplicate_header_row.py
+++ b/tests/test_remove_duplicate_header_row.py
@@ -12,28 +12,51 @@ class TestRemoveDuplicateHeaderRow(unittest.TestCase):
 
         viewer = ExcelViewer.__new__(ExcelViewer)
         viewer.report_config = {
-            'header_rows': [0],
-            'skip_rows': 1,
-            'first_data_column': 1,
-            'description': ''
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 1,
+            "description": "",
         }
 
         # Row 0 is the header, row 1 repeats the header which should be removed
-        df = pd.DataFrame([
-            ['A', 'B', 'C'],
-            ['A', 'B', 'C'],
-            ['desc', '1', '2'],
-        ])
+        df = pd.DataFrame(
+            [
+                ["A", "B", "C"],
+                ["A", "B", "C"],
+                ["desc", "1", "2"],
+            ]
+        )
 
-        cleaned = ExcelViewer._clean_dataframe(viewer, df, 'Sheet1')
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "Sheet1")
         self.assertIsNotNone(cleaned)
         # After removing the duplicate header row we should only have one data row
         self.assertEqual(len(cleaned), 1)
-        self.assertEqual(list(cleaned.columns), ['Sheet_Name', 'A', 'B', 'C'])
-        self.assertEqual(cleaned.iloc[0, 1], 'desc')
+        self.assertEqual(list(cleaned.columns), ["Sheet_Name", "A", "B", "C"])
+        self.assertEqual(cleaned.iloc[0, 1], "desc")
         self.assertEqual(cleaned.iloc[0, 2], 1.0)
         self.assertEqual(cleaned.iloc[0, 3], 2.0)
 
+    def test_duplicate_header_row_removed_with_sheet_col(self):
+        """Duplicate header rows should be removed when a Sheet column exists."""
+        from src.ui.excel_viewer import ExcelViewer
 
-if __name__ == '__main__':
+        viewer = ExcelViewer.__new__(ExcelViewer)
+        viewer.report_type = "AR Center"
+        viewer.report_config = {
+            "header_rows": [0],
+            "skip_rows": 1,
+            "first_data_column": 1,
+            "description": "",
+        }
+
+        df = pd.DataFrame([["A", "B"], ["A", "B"], ["desc", "1"]])
+
+        cleaned = ExcelViewer._clean_dataframe(viewer, df, "facility")
+        self.assertIsNotNone(cleaned)
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(list(cleaned.columns), ["Sheet", "A", "B"])
+        self.assertEqual(cleaned.iloc[0].tolist(), ["facility", "desc", 1.0])
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- strengthen detection and filtering of duplicate header rows
- handle "Sheet" column when dropping duplicates
- ensure blank rows with zero values are removed for Corp SOO
- add regression tests for repeated headers and zero-only rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687fcf7748488332b3acee5103cec89f