### PR TITLE
Improve formula error handling

### DIFF
--- a/tests/test_account_categories.py
+++ b/tests/test_account_categories.py
@@ -77,6 +77,14 @@ class TestCategoryCalculator(unittest.TestCase):
         result = calc.compute(list(self.rows))
         self.assertTrue(any(r["CAReportName"] == "Net Profit" for r in result))
 
+    def test_invalid_formula_returns_error_message(self):
+        formulas = {"Bad": {"expr": "CatA +", "display_name": "Bad"}}
+        calc = CategoryCalculator(self.categories, formulas)
+        result = calc.compute(list(self.rows))
+        bad = next(r for r in result if r["CAReportName"] == "Bad")
+        self.assertIsInstance(bad["Amount"], str)
+        self.assertIn("Bad", bad["Amount"])
+
     def test_compute_detects_account_column(self):
         rows = [
             {"Center": 1, "Account": "1234-5678", "Amount": -100},


### PR DESCRIPTION
## Summary
- log and report formula evaluation errors in `CategoryCalculator`
- test that invalid formulas show an error message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687fde7ee8fc83328201b98bc9055f1f