### PR TITLE
Fix sheet-specific formulas in results viewer

### DIFF
--- a/src/ui/results_viewer.py
+++ b/src/ui/results_viewer.py
@@ -385,10 +385,8 @@ class ResultsViewer(QWidget):
                         sheet_val = parent.sheet_selector.currentText()
                     except Exception:
                         sheet_val = ""
-                if not sheet_val and hasattr(parent, "config"):
-                    sheet_val = parent.config.get("excel", "sheet_name") or ""
 
-                categories = parent.config.get_account_categories(report_type)
+                categories = parent.config.get_account_categories(report_type, sheet_val or None)
                 formulas = parent.config.get_report_formulas(report_type, sheet_val or None)
                 if categories:
                     sheet_col = None


### PR DESCRIPTION
## Summary
- filter account categories per sheet
- avoid extra config sheet name lookup
- test that formulas are only inserted for their configured sheets

## Testing
- `pytest -k results_viewer -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687fe056aba48332952a2b18b1c3fe10