### PR TITLE
Remove unused formula config hooks

### DIFF
--- a/tests/test_open_account_categories_sql.py
+++ b/tests/test_open_account_categories_sql.py
@@ -13,9 +13,6 @@ class DummyConfig:
     def get_account_categories(self, report_type, sheet_name=None):
         return {}
 
-    def get_account_formulas(self, report_type, sheet_name=None):
-        return {}
-
 
 class DummySelector:
     def __init__(self, text):
@@ -53,6 +50,8 @@ class TestOpenAccountCategoriesSQL(unittest.TestCase):
             def __init__(self, config, report_type, accounts, sheet_names=None, parent=None):
                 captured['accounts'] = accounts
                 captured['sheets'] = sheet_names
+            def refresh_accounts(self, accounts):
+                captured['refresh'] = accounts
             def exec(self):
                 return True
 
@@ -73,6 +72,7 @@ class TestOpenAccountCategoriesSQL(unittest.TestCase):
 
         self.assertEqual(captured.get('accounts'), ['1234-5678', '9999-0000'])
         self.assertEqual(captured.get('sheets'), [])
+        self.assertEqual(captured.get('refresh'), ['1234-5678', '9999-0000'])
         self.assertEqual(window.status_bar.message, 'Account categories updated')
 
 

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -13,7 +13,6 @@ FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 class DummyConfig:
     def __init__(self):
         self.categories = {}
-        self.report_formulas = {}
         self.report_type = ""
 
     def get_account_categories(self, report_type, sheet_name=None):
@@ -22,21 +21,10 @@ class DummyConfig:
             return mapping.get("__default__", {})
         return mapping.get(sheet_name) or mapping.get("__default__", {})
 
-    def get_report_formulas(self, report_type, sheet_name=None):
-        mapping = self.report_formulas.get(report_type, {})
-        result = {}
-        for name, info in mapping.items():
-            sheets = info.get("sheets") or []
-            if sheet_name is None or not sheets or sheet_name in sheets or "__default__" in sheets:
-                result[name] = info
-        return result
-
     def set_account_categories(self, report_type, cats, sheet_name=None):
         sheet_name = sheet_name or "__default__"
         self.categories.setdefault(report_type, {})[sheet_name] = cats
 
-    def set_report_formulas(self, report_type, formulas):
-        self.report_formulas[report_type] = formulas
 
     def get(self, section, key=None):
         if section == "excel" and key == "report_type":


### PR DESCRIPTION
## Summary
- drop `report_formulas`, `account_formulas`, and `formula_library` from default config and migrations
- delete unused getters/setters for formula features
- clean up tests for removed config API

## Testing
- `pytest -q` *(fails: 42 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8c24709c8332b63ee1172635f6b6