### PR TITLE
Handle non-numeric mismatch values in PDF report

### DIFF
--- a/tests/fixtures/results_textual_mismatches.csv
+++ b/tests/fixtures/results_textual_mismatches.csv
@@ -1,0 +1,4 @@
+Field,Excel Value,DataBase Value,Variance,Result,Issue,Sheet,Center,CAReport Name
+Metric A,Alpha,Beta,Not Numeric,Does Not Match,,,Center 1,Revenue Quality
+Metric B,1000,Missing entry,500,Does Not Match,,,Center 2,Expense Quality
+Metric C,200,200,0,Match,,,Center 3,Ignore Me

--- a/tests/test_generate_pdf_report.py
+++ b/tests/test_generate_pdf_report.py
@@ -1,0 +1,31 @@
+import importlib
+from pathlib import Path
+
+
+def test_generate_pdf_report_handles_textual_mismatches(monkeypatch, tmp_path):
+    module = importlib.import_module("src.reporting.generate_pdf_report")
+    module = importlib.reload(module)
+
+    fixture_path = Path(__file__).parent / "fixtures" / "results_textual_mismatches.csv"
+    monkeypatch.setattr(module, "RESULTS_CSV", str(fixture_path))
+
+    output_html = tmp_path / "report.html"
+    monkeypatch.setattr(module, "OUTPUT_HTML", str(output_html))
+
+    def fake_chart(match_count, mismatch_count):
+        chart_path = tmp_path / "chart.png"
+        chart_path.write_bytes(b"")
+        return str(chart_path)
+
+    monkeypatch.setattr(module, "create_modern_pie_chart", fake_chart)
+
+    module.main()
+
+    assert output_html.exists(), "Expected PDF HTML output to be generated"
+    html_content = output_html.read_text(encoding="utf-8")
+
+    assert "Not Numeric" in html_content
+    assert "Alpha" in html_content
+    assert "Missing entry" in html_content
+    assert "$1,000.00" in html_content
+    assert "$500.00" in html_content


### PR DESCRIPTION
## Summary
- update the PDF report generator to gracefully format mismatch table values, falling back to readable text when numeric conversion fails
- add a regression fixture with textual mismatch data and a test that verifies the report renders both textual and numeric values without errors

## Testing
- pytest tests/test_generate_pdf_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d440541a708332825a2a7b59bc16b3